### PR TITLE
CombatMove Refactoring and Combat End

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/combat/CombatActions.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/CombatActions.java
@@ -1,20 +1,13 @@
 package com.csse3200.game.components.combat;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Screen;
-import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.csse3200.game.GdxGame;
 import com.csse3200.game.components.CombatStatsComponent;
-import com.csse3200.game.entities.Entity;
 import com.csse3200.game.components.Component;
-import com.csse3200.game.screens.LoadingScreen;
 import com.csse3200.game.services.ServiceContainer;
-import com.csse3200.game.services.ServiceLocator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.awt.*;
 
 /**
  * This class listens to events relevant to the combat screen and does something when one of the
@@ -22,28 +15,21 @@ import java.awt.*;
  */
 public class CombatActions extends Component {
   private static final Logger logger = LoggerFactory.getLogger(CombatActions.class);
-  private GdxGame game;
+  private final GdxGame game;
   private final CombatManager manager;
+  private final Screen previousScreen;
+  private final ServiceContainer previousServices;
   private Stage stage;
-  private CombatButtonDisplay Display;
-  private Screen screen;
-  private ServiceContainer container;
 
-
-  public CombatActions(GdxGame game, CombatManager manager) {
+  public CombatActions(GdxGame game, CombatManager manager, Screen previousScreen, ServiceContainer previousServices) {
     this.game = game;
     this.manager = manager;
+    this.previousScreen = previousScreen;
+    this.previousServices = previousServices;
   }
 
-  /**
-   * Called when the screen is resized.
-   *
-   * @param width  The new width of the screen.
-   * @param height The new height of the screen.
-   */
   @Override
   public void create() {
-    entity.getEvents().addListener("returnToMainGame", this::onReturnToMainGame);
     entity.getEvents().addListener("combatWin", this::onCombatWin);
     entity.getEvents().addListener("combatLose", this::onCombatLoss);
     entity.getEvents().addListener("Attack", this::onAttack);
@@ -54,28 +40,14 @@ public class CombatActions extends Component {
     logger.info("Enemy health start: {}", manager.getEnemy().getComponent(CombatStatsComponent.class).getHealth());
   }
 
-  private void onReturnToMainGame(Screen screen, ServiceContainer container) {
-    logger.info("Returning to main game screen");
-    // change to new GDXgame function
-    game.setOldScreen(screen, container);
-  }
-
   /**
    * Swaps from combat screen to Main Game screen in the event of a won combat sequence.
    * 'Kills' enemy entity on return to combat screen.
    */
-  private void onCombatWin(Screen screen, ServiceContainer container) {
+  private void onCombatWin() {
     logger.info("Returning to main game screen after combat win.");
-    // Kill enemy.
-    //this.enemy.dispose();
-    //this.enemy.update();
-    //container.getEntityService().unregister(enemy);
-    //container.getEntityService().update();
-    // Set current screen to original MainGameScreen
-//    game.setOldScreen(screen, container);
-    logger.info("Player health now: {}", manager.getPlayer().getComponent(CombatStatsComponent.class).getHealth());
-    logger.info("Enemy health now: {}", manager.getEnemy().getComponent(CombatStatsComponent.class).getHealth());
-    game.setScreen(GdxGame.ScreenType.GAME_OVER_WIN);
+    // Reset player's stamina.
+    game.setOldScreen(previousScreen, previousServices);
   }
 
   /**
@@ -83,10 +55,9 @@ public class CombatActions extends Component {
    */
   private void onCombatLoss(Screen screen, ServiceContainer container) {
     logger.info("Returning to main game screen after combat loss.");
-    // Set current screen to original MainGameScreen
-//    game.setOldScreen(screen, container);
-    game.setScreen(GdxGame.ScreenType.GAME_OVER_LOSE);
+    game.setOldScreen(previousScreen, previousServices);
   }
+
   private void onAttack(Screen screen, ServiceContainer container) {
     logger.info("Attack clicked.");
     manager.onPlayerActionSelected("ATTACK");

--- a/source/core/src/main/com/csse3200/game/components/combat/CombatExitDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/CombatExitDisplay.java
@@ -1,12 +1,10 @@
 package com.csse3200.game.components.combat;
 
-import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
-import com.csse3200.game.services.ServiceContainer;
 import com.csse3200.game.ui.UIComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,13 +16,6 @@ public class CombatExitDisplay extends UIComponent {
   private static final Logger logger = LoggerFactory.getLogger(CombatExitDisplay.class);
   private static final float Z_INDEX = 2f;
   private Table table;
-  private final Screen screen;
-  private final ServiceContainer container;
-
-  public CombatExitDisplay(Screen screen, ServiceContainer container) {
-    this.screen = screen;
-    this.container = container;
-  }
 
     @Override
   public void create() {
@@ -44,9 +35,7 @@ public class CombatExitDisplay extends UIComponent {
       new ChangeListener() {
         @Override
         public void changed(ChangeEvent changeEvent, Actor actor) {
-          entity.getEvents().trigger("KangaDefeated", "add", 1);
-          entity.getEvents().trigger("combatWin", screen, container);
-
+          entity.getEvents().trigger("combatWin");
         }
       });
 
@@ -55,7 +44,7 @@ public class CombatExitDisplay extends UIComponent {
       new ChangeListener() {
         @Override
         public void changed(ChangeEvent changeEvent, Actor actor) {
-          entity.getEvents().trigger("combatLose", screen, container);
+          entity.getEvents().trigger("combatLoss");
         }
       });
 

--- a/source/core/src/main/com/csse3200/game/components/combat/CombatManager.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/CombatManager.java
@@ -18,16 +18,20 @@ public class CombatManager extends Component {
     private final Entity enemy;
     private final CombatStatsComponent playerStats;
     private final CombatStatsComponent enemyStats;
-    private final CombatStatsDisplay statsDisplay;
     private Action playerAction;
     private Action enemyAction;
     private final CombatMoveComponent playerMove;
     private final CombatMoveComponent enemyMove;
 
-    public CombatManager(Entity player, Entity enemy, CombatStatsDisplay statsDisplay) {
+    /**
+     * A combat manager which handles enemy move selection, player and enemy move combinations, move sequencing,
+     * combat logic, and checking whether the combat sequence is over.
+     * @param player player entity involved in combat.
+     * @param enemy enemy entity involved in combat.
+     */
+    public CombatManager(Entity player, Entity enemy) {
         this.player = player;
         this.enemy = enemy;
-        this.statsDisplay = statsDisplay;
 
         this.playerStats = player.getComponent(CombatStatsComponent.class);
         this.enemyStats = enemy.getComponent(CombatStatsComponent.class);
@@ -56,7 +60,7 @@ public class CombatManager extends Component {
 
         enemyAction = selectEnemyMove();
 
-        logger.debug("Player action = {}, enemy action = {}", playerAction, enemyAction);
+        logger.info("Player action = {}, enemy action = {}", playerAction, enemyAction);
 
         executeMoveCombination(playerAction, enemyAction);
     }
@@ -66,22 +70,13 @@ public class CombatManager extends Component {
         Action enemyAction;
 
         int rand = (int) (Math.random() * 4);
-        switch (rand) {
-            case 0:
-                enemyAction = Action.ATTACK;
-                break;
-            case 1:
-                enemyAction = Action.GUARD;
-                break;
-            case 2:
-                enemyAction = Action.SLEEP;
-                break;
-            case 3:
-                enemyAction = Action.SPECIAL;
-                break;
-            default:
-                enemyAction = null;
-        }
+        enemyAction = switch (rand) {
+            case 0 -> Action.ATTACK;
+            case 1 -> Action.GUARD;
+            case 2 -> Action.SLEEP;
+            case 3 -> Action.SPECIAL;
+            default -> null;
+        };
 
         return enemyAction;
     }
@@ -127,7 +122,7 @@ public class CombatManager extends Component {
                      * Stamina decreases for both.
                      */
                         // enemy.guard() - Guard move should probably not actually do anything except reduce stamina.
-                        // player.attack(bool guarded = true)
+                        // playerMove.executeMove(playerAction, enemyStats); //////////////////////////////////////////////// NEEDS boolean targetIsGuarded OVERLOAD IN COMBATMOVECOMPONENT *cry emoji*
                         // checkCombatEnd()
                         break;
                     case Action.SLEEP:
@@ -268,9 +263,13 @@ public class CombatManager extends Component {
     }
 
     private void checkCombatEnd() {
-        if (playerStats.getHealth() <= 0 || enemyStats.getHealth() <= 0) {
-            // End combat
-            logger.info("Combat ended");
+        logger.info("Checking combat end: player health = {}, enemy health = {}", playerStats.getHealth(), enemyStats.getHealth());
+        if (playerStats.getHealth() <= 0) {
+            entity.getEvents().trigger("combatLoss");
+            logger.info("Combat lost in manager.");
+        } else if (enemyStats.getHealth() <= 0) {
+            entity.getEvents().trigger("combatWin");
+            logger.info("Combat won in manager.");
         }
     }
 

--- a/source/core/src/main/com/csse3200/game/components/combat/CombatManager.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/CombatManager.java
@@ -122,7 +122,7 @@ public class CombatManager extends Component {
                      * Stamina decreases for both.
                      */
                         // enemy.guard() - Guard move should probably not actually do anything except reduce stamina.
-                        // playerMove.executeMove(playerAction, enemyStats); //////////////////////////////////////////////// NEEDS boolean targetIsGuarded OVERLOAD IN COMBATMOVECOMPONENT *cry emoji*
+                        playerMove.executeMove(playerAction, enemyStats, true);
                         // checkCombatEnd()
                         break;
                     case Action.SLEEP:

--- a/source/core/src/main/com/csse3200/game/components/combat/move/AttackMove.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/move/AttackMove.java
@@ -11,24 +11,34 @@ public class AttackMove extends CombatMove {
         super(moveName, staminaCost);
     }
 
+    @Override
+    public void execute(CombatStatsComponent attackerStats) {
+        logger.error("Attack move needs more arguments.");
+    }
+
+    @Override
+    public void execute(CombatStatsComponent attackerStats, CombatStatsComponent targetStats) {
+        execute(attackerStats, targetStats, false);
+    }
+
     /**
      * The attacker damages the target with an attack move. Stamina is used in doing so.
+     * Attack damage dependent on target's stats and whether they used a Guard move.
      *
      * @param attackerStats combat stats of the attacker.
      * @param targetStats combat stats of the target.
      */
     @Override
-    public void execute(CombatStatsComponent attackerStats, CombatStatsComponent targetStats) {
-
+    public void execute(CombatStatsComponent attackerStats, CombatStatsComponent targetStats, boolean targetIsGuarded)
+    {
         if (attackerStats != null && targetStats != null) {
 
-            int damage = calculateDamage(attackerStats, targetStats);
+            int damage = calculateDamage(attackerStats, targetStats, targetIsGuarded);
 
             targetStats.setHealth(targetStats.getHealth() - damage);
 
             attackerStats.addStamina(-(this.staminaCost));
 
-            //logger.info("{} uses {} on {} dealing {} damage.", attacker, moveName, target, damage);
         } else {
             logger.error("Either attacker or target does not have CombatStatsComponent.");
         }
@@ -44,12 +54,15 @@ public class AttackMove extends CombatMove {
      * @param targetStats combat stats of the target.
      * @return the damage to be inflicted on the target.
      */
-    private int calculateDamage(CombatStatsComponent attackerStats, CombatStatsComponent targetStats) {
+    private int calculateDamage(
+            CombatStatsComponent attackerStats, CombatStatsComponent targetStats, boolean targetIsGuarded
+    )
+    {
         int damage;
 
         double m1 = calculateStatusMultiplier();
         double m2 = calculateStaminaMultiplier(attackerStats.getStamina());
-        double m3 = calculateGuardMultiplier(false); ///////////////////////////////////////////////////// REFACTOR execute() TO PASS IN boolean targetIsGuarded
+        double m3 = calculateGuardMultiplier(targetIsGuarded); ///////////////////////////////////////////////////// REFACTOR execute() TO PASS IN boolean targetIsGuarded
         double m4 = calculateMultiHitMultiplier(1);
         int L = 1; // Level of the user.
         int A = attackerStats.getStrength(); // user's strength stat

--- a/source/core/src/main/com/csse3200/game/components/combat/move/AttackMove.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/move/AttackMove.java
@@ -34,6 +34,7 @@ public class AttackMove extends CombatMove {
         if (attackerStats != null && targetStats != null) {
 
             int damage = calculateDamage(attackerStats, targetStats, targetIsGuarded);
+            logger.info("Attacker is inflicting {} damage", damage);
 
             targetStats.setHealth(targetStats.getHealth() - damage);
 
@@ -62,7 +63,7 @@ public class AttackMove extends CombatMove {
 
         double m1 = calculateStatusMultiplier();
         double m2 = calculateStaminaMultiplier(attackerStats.getStamina());
-        double m3 = calculateGuardMultiplier(targetIsGuarded); ///////////////////////////////////////////////////// REFACTOR execute() TO PASS IN boolean targetIsGuarded
+        double m3 = calculateGuardMultiplier(targetIsGuarded);
         double m4 = calculateMultiHitMultiplier(1);
         int L = 1; // Level of the user.
         int A = attackerStats.getStrength(); // user's strength stat

--- a/source/core/src/main/com/csse3200/game/components/combat/move/AttackMove.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/move/AttackMove.java
@@ -37,7 +37,7 @@ public class AttackMove extends CombatMove {
 
             targetStats.setHealth(targetStats.getHealth() - damage);
 
-            attackerStats.addStamina(-(this.staminaCost));
+            attackerStats.addStamina(-(this.getStaminaCost()));
 
         } else {
             logger.error("Either attacker or target does not have CombatStatsComponent.");

--- a/source/core/src/main/com/csse3200/game/components/combat/move/CombatMove.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/move/CombatMove.java
@@ -11,7 +11,12 @@ public abstract class CombatMove {
         this.staminaCost = staminaCost;
     }
 
-    public abstract void execute(CombatStatsComponent attacker, CombatStatsComponent target);
+    public abstract void execute(CombatStatsComponent attacker);
+
+    public abstract void execute(CombatStatsComponent attackerStats, CombatStatsComponent targetStats);
+
+    public abstract void execute(
+            CombatStatsComponent attackerStats, CombatStatsComponent targetStats, boolean targetIsGuarded);
 
     public String getMoveName() {
         return moveName;

--- a/source/core/src/main/com/csse3200/game/components/combat/move/CombatMoveComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/move/CombatMoveComponent.java
@@ -15,10 +15,26 @@ public class CombatMoveComponent extends Component {
     }
 
     // Execute the move based on MoveAction enum
+    public void executeMove(CombatManager.Action action) {
+        CombatMove move = getMoveAction(action);
+        if (move != null) {
+            move.execute(entity.getComponent(CombatStatsComponent.class));
+        }
+    }
+
+    // Execute the move based on MoveAction enum
     public void executeMove(CombatManager.Action action, CombatStatsComponent target) {
         CombatMove move = getMoveAction(action);
         if (move != null) {
             move.execute(entity.getComponent(CombatStatsComponent.class), target); // entity is the attacker
+        }
+    }
+
+    // Execute the move based on MoveAction enum
+    public void executeMove(CombatManager.Action action, CombatStatsComponent target, boolean targetIsGuarded) {
+        CombatMove move = getMoveAction(action);
+        if (move != null) {
+            move.execute(entity.getComponent(CombatStatsComponent.class), target, targetIsGuarded); // entity is the attacker
         }
     }
 

--- a/source/core/src/main/com/csse3200/game/components/combat/move/GuardMove.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/move/GuardMove.java
@@ -9,6 +9,16 @@ public class GuardMove extends CombatMove {
     }
 
     @Override
+    public void execute(CombatStatsComponent attacker) {
+    }
+
+    @Override
     public void execute(CombatStatsComponent attackerStats, CombatStatsComponent targetStats) {
+        execute(attackerStats);
+    }
+
+    @Override
+    public void execute(CombatStatsComponent attackerStats, CombatStatsComponent targetStats, boolean targetIsGuarded) {
+        execute(attackerStats);
     }
 }

--- a/source/core/src/main/com/csse3200/game/components/combat/move/GuardMove.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/move/GuardMove.java
@@ -1,7 +1,6 @@
 package com.csse3200.game.components.combat.move;
 
 import com.csse3200.game.components.CombatStatsComponent;
-import com.csse3200.game.entities.Entity;
 
 public class GuardMove extends CombatMove {
     public GuardMove(String moveName, int staminaCost) {

--- a/source/core/src/main/com/csse3200/game/components/combat/move/SleepMove.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/move/SleepMove.java
@@ -8,6 +8,16 @@ public class SleepMove extends CombatMove {
     }
 
     @Override
+    public void execute(CombatStatsComponent attackerStats) {
+    }
+
+    @Override
     public void execute(CombatStatsComponent attackerStats, CombatStatsComponent targetStats) {
+        execute(attackerStats);
+    }
+
+    @Override
+    public void execute(CombatStatsComponent attackerStats, CombatStatsComponent targetStats, boolean targetIsGuarded) {
+        execute(attackerStats);
     }
 }

--- a/source/core/src/main/com/csse3200/game/components/combat/move/SpecialMove.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/move/SpecialMove.java
@@ -9,6 +9,14 @@ public class SpecialMove extends CombatMove {
     }
 
     @Override
+    public void execute(CombatStatsComponent attackerStats) {
+    }
+
+    @Override
     public void execute(CombatStatsComponent attackerStats, CombatStatsComponent targetStats) {
+    }
+
+    @Override
+    public void execute(CombatStatsComponent attackerStats, CombatStatsComponent targetStats, boolean targetIsGuarded) {
     }
 }

--- a/source/core/src/main/com/csse3200/game/components/combat/move/SpecialMove.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/move/SpecialMove.java
@@ -1,7 +1,6 @@
 package com.csse3200.game.components.combat.move;
 
 import com.csse3200.game.components.CombatStatsComponent;
-import com.csse3200.game.entities.Entity;
 
 public class SpecialMove extends CombatMove {
     public SpecialMove(String moveName, int staminaCost) {

--- a/source/core/src/main/com/csse3200/game/screens/CombatScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/CombatScreen.java
@@ -6,8 +6,6 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.csse3200.game.GdxGame;
 import com.csse3200.game.components.combat.*;
-import com.csse3200.game.overlays.Overlay;
-import com.csse3200.game.overlays.PauseOverlay;
 import com.csse3200.game.components.CombatStatsComponent;
 import com.csse3200.game.entities.Entity;
 import com.csse3200.game.entities.EntityService;
@@ -27,9 +25,6 @@ import com.csse3200.game.ui.terminal.Terminal;
 import com.csse3200.game.ui.terminal.TerminalDisplay;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Deque;
-import java.util.LinkedList;
 
 /**
  * The game screen containing the combat feature.
@@ -51,8 +46,8 @@ public class CombatScreen extends ScreenAdapter {
   private final ServiceContainer oldScreenServices;
   private final Entity player;
   private final Entity enemy;
-  private CombatStatsComponent playerCombatStats;
-  private CombatStatsComponent enemyCombatStats;
+  private final CombatStatsComponent playerCombatStats;
+  private final CombatStatsComponent enemyCombatStats;
 
 
   public CombatScreen(GdxGame game, Screen screen, ServiceContainer container, Entity player, Entity enemy) {
@@ -151,14 +146,14 @@ public class CombatScreen extends ScreenAdapter {
         ServiceLocator.getInputService().getInputFactory().createForTerminal();
 
     CombatStatsDisplay statsDisplay = new CombatStatsDisplay(playerCombatStats, enemyCombatStats);
-    // Initialise combat manager with instances of player and enemy to be passed into combat actions.
-    CombatManager manager = new CombatManager(player, enemy, statsDisplay);
+    // Initialise combat manager with instances of player and enemy, to be passed into combat actions.
+    CombatManager manager = new CombatManager(player, enemy);
 
     Entity ui = new Entity();
     ui.addComponent(new InputDecorator(stage, 10))
-        .addComponent(new CombatActions(this.game, manager))
-        .addComponent(new CombatExitDisplay(oldScreen, oldScreenServices))
-        .addComponent(new CombatEnvironmentDisplay())
+        .addComponent(new CombatActions(this.game, manager, oldScreen, oldScreenServices))
+        //.addComponent(new CombatEnvironmentDisplay())
+        .addComponent(new CombatExitDisplay())
         .addComponent(statsDisplay)
         .addComponent(new Terminal())
         .addComponent(inputComponent)


### PR DESCRIPTION
Pretty small changes that I've tried to keep contained and hopefully shouldn't overlap onto anything you guys may be doing.

- Added functionality to pass targetIsGuarded flag into AttackMove's execute(). Only way I could do this is to add overloaded functions in CombatMove class, and then Override them in each extension class. This shouldn't impact on functionality of these classes. Actually, it allows for classes like SleepMove and GuardMove to only require one parameter (attackerStats) and gets rid of the redundant passing of targetStats.
- Refactored CombatActions, CombatScreen and CombatManager to be able to exit to the MainGameScreen on either combat loss or combat win. This should work and should be called from the checkCombatEnd() function in CombatManager. The exit buttons also trigger the same listener, so these mimic the functionality in checkCombatEnd().