### PR TITLE
Added basic player information saving and loading

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/ForestGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/ForestGameArea.java
@@ -108,14 +108,7 @@ public class ForestGameArea extends GameArea {
       player.getEvents().addListener("dropItems", this::spawnEntityNearPlayer);
       kangarooBossSpawned = false;
 
-
-
-      if(MainMenuActions.getGameLoaded()) {
-          SaveHandler.load(GameState.class, "saves");
-      } else {
-          GameState.clearState();
-      }
-
+      //Initialise inventory and quests with loaded data
       player.getComponent(PlayerInventoryDisplay.class).loadInventoryFromSave();
       player.getComponent(QuestManager.class).loadQuests();
   }

--- a/source/core/src/main/com/csse3200/game/components/animal/AnimalSelectionActions.java
+++ b/source/core/src/main/com/csse3200/game/components/animal/AnimalSelectionActions.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.csse3200.game.GdxGame;
+import com.csse3200.game.gamestate.GameState;
 import com.csse3200.game.screens.LoadingScreen;
 import com.csse3200.game.ui.PopUpDialogBox.PopUpHelper;
 import org.slf4j.Logger;
@@ -119,6 +120,7 @@ public class AnimalSelectionActions {
 
         selectedAnimalImage = animalImage;
         selectedAnimalImagePath = animalImagePath;
+        GameState.player.selectedAnimalPath = animalImagePath;
         selectedAnimalImage.setColor(1, 0, 0, 1); // Highlight the selected image
 
         logger.debug("Animal selected: {}", animalImage.getName());

--- a/source/core/src/main/com/csse3200/game/components/gamearea/GameAreaDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/gamearea/GameAreaDisplay.java
@@ -7,6 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.utils.Align;
+import com.csse3200.game.gamestate.GameState;
 import com.csse3200.game.ui.UIComponent;
 import com.csse3200.game.entities.factories.PlayerFactory;
 
@@ -45,7 +46,7 @@ public class GameAreaDisplay extends UIComponent {
         title = new Label(this.gameAreaName, skin, "large");
 
         // Get the player image path from PlayerFactory
-        String playerImagePath = PlayerFactory.getSelectedAnimalImagePath();
+        String playerImagePath = GameState.player.selectedAnimalPath;
 
         // Determine the player icon texture based on the player image path
         switch (playerImagePath) {

--- a/source/core/src/main/com/csse3200/game/components/mainmenu/MainMenuActions.java
+++ b/source/core/src/main/com/csse3200/game/components/mainmenu/MainMenuActions.java
@@ -4,6 +4,7 @@ import com.csse3200.game.GdxGame;
 import com.csse3200.game.components.Component;
 import com.csse3200.game.gamestate.GameState;
 import com.csse3200.game.gamestate.SaveHandler;
+import com.csse3200.game.gamestate.data.PlayerSave;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +37,9 @@ public class MainMenuActions extends Component {
    */
   private void onStart() {
     logger.info("Start game");
-    loaded = false;
+
+    GameState.clearState();
+
     game.setScreen(GdxGame.ScreenType.ANIMAL_SELECTION);
   }
 
@@ -46,8 +49,16 @@ public class MainMenuActions extends Component {
    */
   private void onLoad() {
     logger.info("Load game");
-    loaded = true;
-    game.setScreen(GdxGame.ScreenType.ANIMAL_SELECTION);
+
+    SaveHandler.load(GameState.class, "saves");
+    if(GameState.player == null) {
+      GameState.player = new PlayerSave();
+    }
+    if(GameState.player.selectedAnimalPath == null) {
+      game.setScreen(GdxGame.ScreenType.ANIMAL_SELECTION);
+    } else {
+      game.setScreen(GdxGame.ScreenType.LOADING_SCREEN);
+    }
   }
 
   /**

--- a/source/core/src/main/com/csse3200/game/entities/factories/PlayerFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/PlayerFactory.java
@@ -17,6 +17,7 @@ import com.csse3200.game.entities.configs.BaseEnemyEntityConfig;
 import com.csse3200.game.entities.configs.BaseEntityConfig;
 import com.csse3200.game.entities.configs.PlayerConfig;
 import com.csse3200.game.files.FileLoader;
+import com.csse3200.game.gamestate.GameState;
 import com.csse3200.game.input.InputComponent;
 import com.csse3200.game.inventory.Inventory;
 import com.csse3200.game.physics.PhysicsLayer;
@@ -44,7 +45,7 @@ public class PlayerFactory {
      * @return entity
      */
     public static Entity createPlayer(GdxGame game) {
-        String imagePath = AnimalSelectionActions.getSelectedAnimalImagePath();
+        String imagePath = GameState.player.selectedAnimalPath;
         InputComponent inputComponent =
                 ServiceLocator.getInputService().getInputFactory().createForPlayer();
 
@@ -128,9 +129,5 @@ public class PlayerFactory {
 
     private PlayerFactory() {
         throw new IllegalStateException("Instantiating static util class");
-    }
-
-    public static String getSelectedAnimalImagePath() {
-        return AnimalSelectionActions.getSelectedAnimalImagePath();
     }
 }

--- a/source/core/src/main/com/csse3200/game/gamestate/GameState.java
+++ b/source/core/src/main/com/csse3200/game/gamestate/GameState.java
@@ -1,6 +1,7 @@
 package com.csse3200.game.gamestate;
 
 import com.csse3200.game.gamestate.data.InventorySave;
+import com.csse3200.game.gamestate.data.PlayerSave;
 import com.csse3200.game.gamestate.data.QuestSave;
 
 /**
@@ -15,8 +16,14 @@ public class GameState {
 
     public static InventorySave inventory = new InventorySave();
 
+    public static PlayerSave player = new PlayerSave();
+
+    /**
+     * Clears the contents of the GameState
+     */
     public static void clearState() {
         quests = new QuestSave();
         inventory = new InventorySave();
+        player = new PlayerSave();
     }
 }

--- a/source/core/src/main/com/csse3200/game/gamestate/data/PlayerSave.java
+++ b/source/core/src/main/com/csse3200/game/gamestate/data/PlayerSave.java
@@ -1,0 +1,5 @@
+package com.csse3200.game.gamestate.data;
+
+public class PlayerSave {
+    public String selectedAnimalPath = null;
+}

--- a/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
@@ -13,6 +13,7 @@ import com.csse3200.game.entities.Entity;
 import com.csse3200.game.entities.EntityService;
 import com.csse3200.game.entities.DialogueBoxService;
 import com.csse3200.game.entities.factories.RenderFactory;
+import com.csse3200.game.gamestate.GameState;
 import com.csse3200.game.input.InputComponent;
 import com.csse3200.game.input.InputDecorator;
 import com.csse3200.game.input.InputService;
@@ -46,7 +47,7 @@ public class MainGameScreen extends PausableScreen {
    * Array of texture paths used in the main game screen.
    */
   private static final String[] mainGameTextures = {"images/health_bar_x1.png",
-          AnimalSelectionActions.getSelectedAnimalImagePath(), "images/player_icon_forest.png", "images/vignette.png",
+          GameState.player.selectedAnimalPath, "images/player_icon_forest.png", "images/vignette.png",
           "images/xp_bar.png", "images/hunger_bar.png", "images/QuestsOverlay/Quest_SBG.png", "images/PauseOverlay/TitleBG.png", "images/PauseOverlay/Button.png"};
   /**
    * Initial position of the camera in game.


### PR DESCRIPTION
Currently saves the selected player animal image, and when loading, skips the animal selection screen. PlayerSave data struct extendable to include further player information.

See #286 