### PR TITLE
Fixed bug which crashes game after Combat Win

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/combat/CombatManager.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/CombatManager.java
@@ -220,8 +220,6 @@ public class CombatManager extends Component {
 
         logger.info("(AFTER) PLAYER: health {}, stamina {}", playerStats.getHealth(), playerStats.getStamina());
         logger.info("(AFTER) ENEMY: health {}, stamina {}", enemyStats.getHealth(), enemyStats.getStamina());
-
-        checkCombatEnd();
     }
 
     /**


### PR DESCRIPTION
Fixed a bug, when you win a combat against an enemy it crashes the game.

To reproduce the error:
- Start game
- Go into combat with an enemy (preferably chicken, since it has the lowest health so attacking it once wins the combat)
- Game crashes

Error cause:
In CombatManager, there's a call to checkCombatEnd() twice which triggers combatWin again, but since the assets are already disposed of it crashes the game.

Fix:
Remove an extra checkCombatEnd() line in CombatManager