### PR TITLE
Fixed bug where exiting and going back into game caused crash

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/MapHandler.java
+++ b/source/core/src/main/com/csse3200/game/areas/MapHandler.java
@@ -1,11 +1,5 @@
 package com.csse3200.game.areas;
 
-import com.badlogic.gdx.Game;
-import com.badlogic.gdx.maps.tiled.TiledMap;
-import com.badlogic.gdx.maps.tiled.TmxMapLoader;
-import com.csse3200.game.areas.ForestGameArea;
-import com.csse3200.game.areas.WaterGameArea;
-import com.csse3200.game.areas.GameArea;
 import com.csse3200.game.areas.terrain.TerrainFactory;
 import com.csse3200.game.rendering.Renderer;
 import com.csse3200.game.GdxGame;
@@ -18,11 +12,11 @@ public class MapHandler {
   private static ForestGameArea forestGameArea;
   private static WaterGameArea waterGameArea;
 
-  private static boolean isSavedPrevioud;
+  private static boolean isSavedPrevious;
   // private static GameArea savedPrevioud;
 
   private MapHandler() {
-    isSavedPrevioud = false;
+    isSavedPrevious = false;
   }
 
   /**
@@ -41,7 +35,7 @@ public class MapHandler {
     // TODO: save state
     if (saveState && currentMap != MapType.NONE) {
       // currentMap.saveState();
-      isSavedPrevioud = true;
+      isSavedPrevious = true;
     }
 
     if (currentMap != MapType.NONE) {
@@ -61,6 +55,46 @@ public class MapHandler {
     previousMap = currentMap;
     currentMap = mapType;
     return currentGameArea;
+  }
+
+  /**
+   * Generates a new map - intended for use when a game is loaded, ie, so that
+   * the new map can be set without attempting to dispose of an old map
+   * (this should be handled by the screen).
+   * NOTE: Erases reference to old map without disposing of it.
+   *
+   * @param mapType - the type of map to initiaise to
+   * @param renderer renderer
+   * @param game game
+   * @return
+   */
+  public static GameArea createNewMap(MapType mapType, Renderer renderer, GdxGame game) {
+    resetMapHandler();
+    currentMap = mapType;
+
+    TerrainFactory terrainFactory = new TerrainFactory(renderer.getCamera());
+
+    if (mapType == MapType.FOREST) {
+      currentGameArea = new ForestGameArea(terrainFactory, game);
+      currentGameArea.create();
+    } else if (mapType == MapType.WATER) {
+      currentGameArea = new WaterGameArea(terrainFactory, game);
+      currentGameArea.create();
+    }
+
+    return currentGameArea;
+  }
+
+  /**
+   * Deletes references to all maps and resets to original state.
+   */
+  private static void resetMapHandler() {
+    currentMap = MapType.NONE;
+    previousMap = MapType.NONE;
+    currentGameArea = null;
+    isSavedPrevious = false;
+    forestGameArea = null;
+    waterGameArea = null;
   }
 
   /**

--- a/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
@@ -120,7 +120,7 @@ public class MainGameScreen extends PausableScreen {
     createUI();
     logger.debug("Initialising main game screen entities");
 
-    setMap(MapHandler.MapType.FOREST);
+    this.gameArea = MapHandler.createNewMap(MapHandler.MapType.FOREST, renderer, this.game);
 
     Stage stage = ServiceLocator.getRenderService().getStage();
     ServiceLocator.registerDialogueBoxService(new DialogueBoxService(stage));


### PR DESCRIPTION
# Description
The change stops double disposal of entities (and double disposal of the ForestGameArea) which caused the game to crash as per #398 . I believe this should also stop the hs_err pid error files from coming up, and also the bug that sometimes occurred upon exiting and re-entering the game where a sound asset file could not be found (I believe it couldn't be found because it was already unloaded from the ResourceService).

Fixes / Closes #398 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Functionally test -> go to main before the additions from this branch. Attempt to go through the bug reproduction procedure described in #398 (the game will crash). Then switch to this branch and again attempt to reproduce the bug following the same procedure and see that it does not occur.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
