### PR TITLE
Fixed Projectile Collision Bug

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/ProjectileAttackComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/ProjectileAttackComponent.java
@@ -66,7 +66,9 @@ public class ProjectileAttackComponent extends Component {
 
     // does damage if player
     Entity target = ((BodyUserData) other.getBody().getUserData()).entity;
-    target.getComponent(CombatStatsComponent.class).addHealth(-2); //placeholder value
+    if (target.isPlayer()) {
+      target.getComponent(CombatStatsComponent.class).addHealth(-2); //placeholder value
+    }
     
     // disposes of projectile
     Entity owner = getEntity();

--- a/source/core/src/main/com/csse3200/game/entities/Entity.java
+++ b/source/core/src/main/com/csse3200/game/entities/Entity.java
@@ -68,8 +68,9 @@ public class Entity {
   }
 
   // Setter for enemy type
-  public void setEnemyType(EnemyType enemyType) {
+  public Entity setEnemyType(EnemyType enemyType) {
     this.enemyType = enemyType;
+    return this;
   }
 
   /**

--- a/source/core/src/main/com/csse3200/game/entities/Entity.java
+++ b/source/core/src/main/com/csse3200/game/entities/Entity.java
@@ -37,6 +37,7 @@ public class Entity {
   private Vector2 position = Vector2.Zero.cpy();
   private Vector2 scale = new Vector2(1, 1);
   private Array<Component> createdComponents;
+  private boolean isPlayer = false;
   private EnemyType enemyType;
   public enum EnemyType {
     KANGAROO,
@@ -48,13 +49,16 @@ public class Entity {
 
 
   public Entity() {
-
     id = nextId;
     nextId++;
 
     components = new IntMap<>(4);
     eventHandler = new EventHandler();
   }
+
+  public void setIsPlayer(boolean status) {this.isPlayer = status;}
+
+  public boolean isPlayer() {return this.isPlayer;}
 
   // Getter for enemy type
   public EnemyType getEnemyType() {
@@ -64,9 +68,8 @@ public class Entity {
   }
 
   // Setter for enemy type
-  public Entity setEnemyType(EnemyType enemyType) {
+  public void setEnemyType(EnemyType enemyType) {
     this.enemyType = enemyType;
-    return this;
   }
 
   /**

--- a/source/core/src/main/com/csse3200/game/entities/factories/PlayerFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/PlayerFactory.java
@@ -50,7 +50,7 @@ public class PlayerFactory {
                 ServiceLocator.getInputService().getInputFactory().createForPlayer();
 
         Entity player =
-                new Entity()
+                new Entity() // Set that this entity is the player
                         .addComponent(new TextureRenderComponent(imagePath))
                         .addComponent(new CameraZoomComponent())
                         .addComponent(new PhysicsComponent(true))
@@ -105,6 +105,8 @@ public class PlayerFactory {
         LightingComponent light = new LightingComponent(LightingComponent.createPointLight(4f, Color.CORAL));
         light.getLight().setContactFilter(PhysicsLayer.DEFAULT, PhysicsLayer.NONE, (short)(PhysicsLayer.OBSTACLE | PhysicsLayer.NPC));
         player.addComponent(light);
+
+        player.setIsPlayer(true);
 
         return player;
     }


### PR DESCRIPTION
# Description
This changes fixes the bug #428 where if a projectile (banana from a monkey) hits a tree the game crashes. I have added a flag to determine whether an entity is a player - and upon player creation this is set (defaults to false). Then, projectiles will only damage the player (ie friendly fire between monkeys or other enemies cannot happen - if we want this to change it can be determined by the design comittee).

Fixes / Closes #428 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Complete the testing protocol described in #428 to reproduce the bug, and observe that in main (before this pr) the game crashes, and afterwards it doesn't.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
