### PR TITLE
1/player sprint3 cut scene

### DIFF
--- a/source/core/src/main/com/csse3200/game/GdxGame.java
+++ b/source/core/src/main/com/csse3200/game/GdxGame.java
@@ -192,7 +192,8 @@ public class GdxGame extends Game {
             case STORY:
                 String selectedAnimal = "dog";  // Replace with actual logic for getting selected animal
                 return new StoryScreen(this, selectedAnimal);
-
+            case CUTSCENE:
+                setScreen(new CutSceneScreen(this));
             case QUICK_TIME_EVENT:
                 return new QuickTimeEventScreen(this);
             default:
@@ -206,7 +207,7 @@ public class GdxGame extends Game {
     public enum ScreenType {
         MAIN_MENU, MAIN_GAME, SETTINGS, MINI_GAME_MENU_SCREEN, LOADING_SCREEN, ANIMAL_SELECTION,
         ACHIEVEMENTS, COMBAT, BOSS_CUTSCENE, ENEMY_CUTSCENE, GAME_OVER_LOSE, SNAKE_MINI_GAME,
-        BIRD_MINI_GAME, MAZE_MINI_GAME, QUICK_TIME_EVENT, END_GAME_STATS, STORY
+        BIRD_MINI_GAME, MAZE_MINI_GAME, QUICK_TIME_EVENT, END_GAME_STATS, CUTSCENE, STORY
     }
 
     /**

--- a/source/core/src/main/com/csse3200/game/GdxGame.java
+++ b/source/core/src/main/com/csse3200/game/GdxGame.java
@@ -193,7 +193,7 @@ public class GdxGame extends Game {
                 String selectedAnimal = "dog";  // Replace with actual logic for getting selected animal
                 return new StoryScreen(this, selectedAnimal);
             case CUTSCENE:
-                setScreen(new CutSceneScreen(this));
+                return (new CutSceneScreen(this));
             case QUICK_TIME_EVENT:
                 return new QuickTimeEventScreen(this);
             default:

--- a/source/core/src/main/com/csse3200/game/components/mainmenu/MainMenuActions.java
+++ b/source/core/src/main/com/csse3200/game/components/mainmenu/MainMenuActions.java
@@ -42,7 +42,7 @@ public class MainMenuActions extends Component {
 
     GameState.resetState();
 
-    game.setScreen(GdxGame.ScreenType.ANIMAL_SELECTION);
+    game.setScreen(GdxGame.ScreenType.CUTSCENE);
   }
 
   /**
@@ -60,7 +60,7 @@ public class MainMenuActions extends Component {
       GameState.resetState();
     }
     if(GameState.player.selectedAnimalPath == null) {
-      game.setScreen(GdxGame.ScreenType.ANIMAL_SELECTION);
+      game.setScreen(GdxGame.ScreenType.CUTSCENE);
     } else {
       game.setScreen(GdxGame.ScreenType.LOADING_SCREEN);
     }

--- a/source/core/src/main/com/csse3200/game/screens/CutSceneScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/CutSceneScreen.java
@@ -2,6 +2,7 @@ package com.csse3200.game.screens;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.ScreenAdapter;
+import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.csse3200.game.GdxGame;
@@ -21,6 +22,8 @@ public class CutSceneScreen extends ScreenAdapter {
     private ResourceService resourceService;
     private SpriteBatch spriteBatch;
     private Stage stage;
+    private Texture cutSceneTexture; // Texture for the cutscene background
+
 
     public CutSceneScreen(GdxGame game) {
         this.game = game;
@@ -54,6 +57,18 @@ public class CutSceneScreen extends ScreenAdapter {
     @Override
     public void resize(int width, int height) {
         renderService.getStage().getViewport().update(width, height, true);
+    }
+    private void loadAssets() {
+        logger.debug("Loading CutScene assets");
+
+        // Load cutscene assets (images, sounds, etc.)
+        resourceService.loadAll();
+
+        // Load the cutscene background image
+        cutSceneTexture = new Texture(Gdx.files.internal("images/BackgroundSplashBasic.png")); // Update the path
+    }
+    private void createCutScene() {
+        logger.debug("Creating CutScene UI");
     }
 
     @Override

--- a/source/core/src/main/com/csse3200/game/screens/CutSceneScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/CutSceneScreen.java
@@ -1,0 +1,43 @@
+package com.csse3200.game.screens;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.ScreenAdapter;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.csse3200.game.GdxGame;
+import com.csse3200.game.entities.EntityService;
+import com.csse3200.game.rendering.RenderService;
+import com.csse3200.game.services.ResourceService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CutSceneScreen extends ScreenAdapter {
+    private static final Logger logger = LoggerFactory.getLogger(CutSceneScreen.class);
+    private final GdxGame game;
+
+    // Local instances of services
+    private RenderService renderService;
+    private EntityService entityService;
+    private ResourceService resourceService;
+    private SpriteBatch spriteBatch;
+    private Stage stage;
+
+    public CutSceneScreen(GdxGame game) {
+        this.game = game;
+
+        logger.debug("Initializing CutScene screen");
+
+        // Initialize the services
+        this.spriteBatch = new SpriteBatch();
+        this.stage = new Stage();
+        this.renderService = new RenderService();  // No arguments in constructor
+        this.entityService = new EntityService();
+        this.resourceService = new ResourceService();
+
+        // Set the stage in the render service
+        renderService.setStage(stage);
+
+        // Set input processor
+        Gdx.input.setInputProcessor(stage);
+    }
+}

--- a/source/core/src/main/com/csse3200/game/screens/CutSceneScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/CutSceneScreen.java
@@ -40,4 +40,32 @@ public class CutSceneScreen extends ScreenAdapter {
         // Set input processor
         Gdx.input.setInputProcessor(stage);
     }
+    @Override
+    public void render(float delta) {
+        // Update entities and render the screen
+        entityService.update();
+        spriteBatch.begin();
+        renderService.render(spriteBatch); // Trigger rendering through RenderService
+        spriteBatch.end();
+        stage.act(delta); // Update the stage
+        stage.draw(); // Draw the stage
+    }
+
+    @Override
+    public void resize(int width, int height) {
+        renderService.getStage().getViewport().update(width, height, true);
+    }
+
+    @Override
+    public void dispose() {
+        logger.debug("Disposing CutScene screen");
+
+        // Dispose of all resources and services
+        renderService.dispose();
+        entityService.dispose();
+        resourceService.loadAll();  // Might need to change this depending on how assets are loaded
+        spriteBatch.dispose();
+        stage.dispose();
+    }
+
 }

--- a/source/core/src/main/com/csse3200/game/screens/CutSceneScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/CutSceneScreen.java
@@ -16,54 +16,50 @@ import com.csse3200.game.services.ResourceService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Represents the cutscene screen that displays
+ * a cutscene before transitioning to the next game state.
+ */
 public class CutSceneScreen extends ScreenAdapter {
     private static final Logger logger = LoggerFactory.getLogger(CutSceneScreen.class);
     private final GdxGame game;
 
-    // Local instances of services
     private RenderService renderService;
     private EntityService entityService;
     private ResourceService resourceService;
     private SpriteBatch spriteBatch;
     private Stage stage;
-    private Texture cutSceneTexture; // Texture for the cutscene background
-    private Skin skin; // Added skin for button styling
-
+    private Texture cutSceneTexture;
+    private Skin skin;
 
     public CutSceneScreen(GdxGame game) {
         this.game = game;
 
         logger.debug("Initializing CutScene screen");
 
-        // Initialize the services
         this.spriteBatch = new SpriteBatch();
         this.stage = new Stage();
-        this.renderService = new RenderService();  // No arguments in constructor
+        this.renderService = new RenderService();
         this.entityService = new EntityService();
         this.resourceService = new ResourceService();
-
-        // Set the stage in the render service
         renderService.setStage(stage);
 
-        // Load assets and create the cutscene
         loadAssets();
         createCutScene();
-        ContinueBtn(); // Add button creation here
+        createContinueButton();
 
-        // Set input processor
         Gdx.input.setInputProcessor(stage);
     }
 
     @Override
     public void render(float delta) {
-        // Update entities and render the screen
         entityService.update();
         spriteBatch.begin();
-        renderService.render(spriteBatch); // Trigger rendering through RenderService
-        spriteBatch.draw(cutSceneTexture, 0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight()); // Draw the cutscene texture
+        renderService.render(spriteBatch);
+        spriteBatch.draw(cutSceneTexture, 0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
         spriteBatch.end();
-        stage.act(delta); // Update the stage
-        stage.draw(); // Draw the stage
+        stage.act(delta);
+        stage.draw();
     }
 
     @Override
@@ -71,57 +67,53 @@ public class CutSceneScreen extends ScreenAdapter {
         renderService.getStage().getViewport().update(width, height, true);
     }
 
+    /**
+     * Loads assets required for the cutscene.
+     */
     private void loadAssets() {
         logger.debug("Loading CutScene assets");
-
-        // Load cutscene assets (images, sounds, etc.)
         resourceService.loadAll();
-
-        // Load the cutscene background image
-        cutSceneTexture = new Texture(Gdx.files.internal("images/BackgroundSplashBasic.png")); // Update the path
+        cutSceneTexture = new Texture(Gdx.files.internal("images/BackgroundSplashBasic.png"));
     }
 
+    /**
+     * Creates the cutscene UI elements.
+     */
     private void createCutScene() {
         logger.debug("Creating CutScene UI");
-
-        // Add logic to create and display the cutscene (animations, UI elements, etc.)
+        // Logic for setting up the cutscene can go here
     }
 
-    private void ContinueBtn() {
+    /**
+     * Creates the continue button for proceeding to the next screen.
+     */
+    private void createContinueButton() {
         logger.debug("Creating Continue button");
+        skin = new Skin(Gdx.files.internal("flat-earth/skin/flat-earth-ui.json"));
 
-        // Initialize skin for button
-        skin = new Skin(Gdx.files.internal("flat-earth/skin/flat-earth-ui.json")); // Replace with actual path to your skin file
-
-        // Create Continue button
         TextButton continueButton = new TextButton("Continue", skin);
-        continueButton.setSize(200, 60); // Set size of the button
-        continueButton.setPosition(stage.getWidth() / 2 - continueButton.getWidth() / 2, 30); // Center it at the bottom
+        continueButton.setSize(200, 60);
+        continueButton.setPosition(stage.getWidth() / 2 - continueButton.getWidth() / 2, 30);
 
-        // Add click listener for Continue button
         continueButton.addListener(new ClickListener() {
             @Override
             public void clicked(InputEvent event, float x, float y) {
                 logger.debug("Continue button clicked");
-                // Add logic to transition to the next screen or state
                 game.setScreen(GdxGame.ScreenType.ANIMAL_SELECTION);
             }
         });
 
-        // Add button to stage
         stage.addActor(continueButton);
     }
 
     @Override
     public void dispose() {
         logger.debug("Disposing CutScene screen");
-
-        // Dispose of all resources and services
         renderService.dispose();
         entityService.dispose();
-        resourceService.loadAll();  // Might need to change this depending on how assets are loaded
+        resourceService.loadAll();
         spriteBatch.dispose();
         stage.dispose();
-        cutSceneTexture.dispose(); // Dispose of the cutscene texture
+        cutSceneTexture.dispose();
     }
 }

--- a/source/core/src/main/com/csse3200/game/screens/CutSceneScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/CutSceneScreen.java
@@ -4,7 +4,11 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.ScreenAdapter;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.csse3200.game.GdxGame;
 import com.csse3200.game.entities.EntityService;
 import com.csse3200.game.rendering.RenderService;
@@ -23,6 +27,7 @@ public class CutSceneScreen extends ScreenAdapter {
     private SpriteBatch spriteBatch;
     private Stage stage;
     private Texture cutSceneTexture; // Texture for the cutscene background
+    private Skin skin; // Added skin for button styling
 
 
     public CutSceneScreen(GdxGame game) {
@@ -40,15 +45,22 @@ public class CutSceneScreen extends ScreenAdapter {
         // Set the stage in the render service
         renderService.setStage(stage);
 
+        // Load assets and create the cutscene
+        loadAssets();
+        createCutScene();
+        ContinueBtn(); // Add button creation here
+
         // Set input processor
         Gdx.input.setInputProcessor(stage);
     }
+
     @Override
     public void render(float delta) {
         // Update entities and render the screen
         entityService.update();
         spriteBatch.begin();
         renderService.render(spriteBatch); // Trigger rendering through RenderService
+        spriteBatch.draw(cutSceneTexture, 0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight()); // Draw the cutscene texture
         spriteBatch.end();
         stage.act(delta); // Update the stage
         stage.draw(); // Draw the stage
@@ -58,6 +70,7 @@ public class CutSceneScreen extends ScreenAdapter {
     public void resize(int width, int height) {
         renderService.getStage().getViewport().update(width, height, true);
     }
+
     private void loadAssets() {
         logger.debug("Loading CutScene assets");
 
@@ -67,8 +80,36 @@ public class CutSceneScreen extends ScreenAdapter {
         // Load the cutscene background image
         cutSceneTexture = new Texture(Gdx.files.internal("images/BackgroundSplashBasic.png")); // Update the path
     }
+
     private void createCutScene() {
         logger.debug("Creating CutScene UI");
+
+        // Add logic to create and display the cutscene (animations, UI elements, etc.)
+    }
+
+    private void ContinueBtn() {
+        logger.debug("Creating Continue button");
+
+        // Initialize skin for button
+        skin = new Skin(Gdx.files.internal("flat-earth/skin/flat-earth-ui.json")); // Replace with actual path to your skin file
+
+        // Create Continue button
+        TextButton continueButton = new TextButton("Continue", skin);
+        continueButton.setSize(200, 60); // Set size of the button
+        continueButton.setPosition(stage.getWidth() / 2 - continueButton.getWidth() / 2, 30); // Center it at the bottom
+
+        // Add click listener for Continue button
+        continueButton.addListener(new ClickListener() {
+            @Override
+            public void clicked(InputEvent event, float x, float y) {
+                logger.debug("Continue button clicked");
+                // Add logic to transition to the next screen or state
+                game.setScreen(GdxGame.ScreenType.ANIMAL_SELECTION);
+            }
+        });
+
+        // Add button to stage
+        stage.addActor(continueButton);
     }
 
     @Override
@@ -81,6 +122,6 @@ public class CutSceneScreen extends ScreenAdapter {
         resourceService.loadAll();  // Might need to change this depending on how assets are loaded
         spriteBatch.dispose();
         stage.dispose();
+        cutSceneTexture.dispose(); // Dispose of the cutscene texture
     }
-
 }


### PR DESCRIPTION
# Description

This pull request implements the CutSceneScreen class, which displays a cutscene in the game. The screen includes a background texture and a "Continue" button that transitions the player to the next screen (Animal Selection).
The new design layout for the screen is yet to be implemented and will be integrated in upcoming days.

Fixes / Closes # (issue)
#382 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
The testing is yet to be implemented 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have added tests that prove my fix is effective or that my feature works
