### PR TITLE
FIX BUG: End of combat dialogue box does not show after win

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/combat/CombatActions.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/CombatActions.java
@@ -78,7 +78,7 @@ public class CombatActions extends Component {
 //
 //      EntityConverter.convertToFriendly(manager.getEnemy(), manager.getPlayer(), enemies);
 //    }
-    game.returnFromCombat(previousScreen, previousServices, enemy);
+//    game.returnFromCombat(previousScreen, previousServices, enemy);
   }
 
   /**
@@ -90,13 +90,10 @@ public class CombatActions extends Component {
     manager.getPlayer().getComponent(CombatStatsComponent.class).setStamina(100);
 
     // For CombatStatsDisplay to update
-    // currently there is no listener for below
-    //entity.getEvents().trigger("onCombatLoss", manager.getPlayerStats());
+    entity.getEvents().trigger("onCombatLoss", manager.getPlayerStats());
 
     // For CombatButtonDisplay DialogueBox
     entity.getEvents().trigger("endOfCombatDialogue", enemy, false);
-
-    game.setOldScreen(previousScreen, previousServices);
   }
 
   /**


### PR DESCRIPTION
# Description

Revert back changes which cause the end of combat dialogue box to not show after win (only just three lines of code).
Back to where it was where it last work in main, which is PR 436

Before fix:
- Start game
- Go into combat with chicken
- Select attack move
- Returns to the main game

After fix:
- Start game
- Go into combat with chicken
- Select attack move
- Shows dialogue box (You tamed .....)
- Returns to the main game

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code