### PR TITLE
[Team 9 & 10] Add Combat Animations for Bosses

### DIFF
--- a/source/core/assets/images/air_boss.atlas
+++ b/source/core/assets/images/air_boss.atlas
@@ -80,3 +80,73 @@ chase
   orig: 146, 162
   offset: 0, 0
   index: 4
+combat_idle
+  rotate: false
+  xy: 0, 0
+  size: 146, 162
+  orig: 146, 162
+  offset: 0, 0
+  index: 0
+combat_idle
+  rotate: false
+  xy: 146, 0
+  size: 146, 162
+  orig: 146, 162
+  offset: 0, 0
+  index: 1
+combat_idle
+  rotate: false
+  xy: 292, 0
+  size: 146, 162
+  orig: 146, 162
+  offset: 0, 0
+  index: 2
+combat_idle
+  rotate: false
+  xy: 438, 0
+  size: 146, 162
+  orig: 146, 162
+  offset: 0, 0
+  index: 3
+combat_idle
+  rotate: false
+  xy: 584, 0
+  size: 146, 162
+  orig: 146, 162
+  offset: 0, 0
+  index: 4
+combat_move
+  rotate: false
+  xy: 0, 162
+  size: 146, 162
+  orig: 146, 162
+  offset: 0, 0
+  index: 0
+combat_move
+  rotate: false
+  xy: 146, 162
+  size: 146, 162
+  orig: 146, 162
+  offset: 0, 0
+  index: 1
+combat_move
+  rotate: false
+  xy: 292, 162
+  size: 146, 162
+  orig: 146, 162
+  offset: 0, 0
+  index: 2
+combat_move
+  rotate: false
+  xy: 438, 162
+  size: 146, 162
+  orig: 146, 162
+  offset: 0, 0
+  index: 3
+combat_move
+  rotate: false
+  xy: 584, 162
+  size: 146, 162
+  orig: 146, 162
+  offset: 0, 0
+  index: 4

--- a/source/core/assets/images/final_boss_kangaroo.atlas
+++ b/source/core/assets/images/final_boss_kangaroo.atlas
@@ -52,3 +52,45 @@ chase
   orig: 64, 64
   offset: 0, 0
   index: 2
+combat_idle
+  rotate: false
+  xy: 0, 0
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 0
+combat_idle
+  rotate: false
+  xy: 64, 0
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 1
+combat_idle
+  rotate: false
+  xy: 128, 0
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 2
+combat_move
+  rotate: false
+  xy: 0, 64
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 0
+combat_move
+  rotate: false
+  xy: 64, 64
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 1
+combat_move
+  rotate: false
+  xy: 128, 64
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 2

--- a/source/core/assets/images/joey.atlas
+++ b/source/core/assets/images/joey.atlas
@@ -94,3 +94,73 @@ spawn
     orig: 20, 23
     offset: 0, 0
     index: 1
+combat_idle
+    rotate: false
+    xy: 7, 3
+    size: 18, 23
+    orig: 18, 23
+    offset: 0, 0
+    index: 0
+combat_idle
+    rotate: false
+    xy: 37, 3
+    size: 21, 23
+    orig: 21, 23
+    offset: 0, 0
+    index: 1
+combat_idle
+    rotate: false
+    xy: 69, 3
+    size: 22, 22
+    orig: 22, 22
+    offset: 0, 0
+    index: 2
+combat_idle
+    rotate: false
+    xy: 103, 3
+    size: 21, 23
+    orig: 21, 23
+    offset: 0, 0
+    index: 3
+combat_move
+    rotate: false
+    xy: 5, 34
+    size: 20, 24
+    orig: 20, 24
+    offset: 0, 0
+    index: 0
+combat_move
+    rotate: false
+    xy: 38, 34
+    size: 21, 23
+    orig: 21, 23
+    offset: 0, 0
+    index: 1
+combat_move
+    rotate: false
+    xy: 72, 34
+    size: 20, 24
+    orig: 20, 24
+    offset: 0, 0
+    index: 2
+combat_move
+    rotate: false
+    xy: 106, 35
+    size: 19, 24
+    orig: 19, 24
+    offset: 0, 0
+    index: 3
+combat_move
+    rotate: false
+    xy: 140, 33
+    size: 19, 24
+    orig: 19, 24
+    offset: 0, 0
+    index: 4
+combat_move
+    rotate: false
+    xy: 171, 33
+    size: 20, 25
+    orig: 20, 25
+    offset: 0, 0
+    index: 5

--- a/source/core/assets/images/water_boss.atlas
+++ b/source/core/assets/images/water_boss.atlas
@@ -94,3 +94,87 @@ chase
   orig: 64, 64
   offset: 0, 0
   index: 5
+combat_idle
+  rotate: false
+  xy: 0, 0
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 0
+combat_idle
+  rotate: false
+  xy: 64, 0
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 1
+combat_idle
+  rotate: false
+  xy: 128, 0
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 2
+combat_idle
+  rotate: false
+  xy: 192, 0
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 3
+combat_idle
+  rotate: false
+  xy: 256, 0
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 4
+combat_idle
+  rotate: false
+  xy: 320, 0
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 5
+combat_move
+  rotate: false
+  xy: 0, 64
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 0
+combat_move
+  rotate: false
+  xy: 64, 64
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 1
+combat_move
+  rotate: false
+  xy: 128, 64
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 2
+combat_move
+  rotate: false
+  xy: 192, 64
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 3
+combat_move
+  rotate: false
+  xy: 256, 64
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 4
+combat_move
+  rotate: false
+  xy: 320, 64
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: 5

--- a/source/core/src/main/com/csse3200/game/areas/CombatArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/CombatArea.java
@@ -229,20 +229,23 @@ public class CombatArea extends GameArea {
 
     /** Spawn a combat enemy. Different to a regular enemy npc */
     private void spawnKangaBoss() {
-        Entity combatEnemyNPC = BossFactory.createKangaBossCombatEntity();
-        spawnEntityAt(combatEnemyNPC, new GridPoint2(800, 346), true, true);
+        Entity enemyDisplay = CombatAnimalFactory.createKangaBossCombatEntity();
+        spawnEntityAt(enemyDisplay, new GridPoint2(800, 346), true, true);
+        this.enemyDisplay = enemyDisplay;
     }
 
     /** Spawn a combat enemy. Different to a regular enemy npc */
     private void spawnWaterBoss() {
-        Entity combatEnemyNPC = BossFactory.createWaterBossCombatEntity();
-        spawnEntityAt(combatEnemyNPC, new GridPoint2(800, 346), true, true);
+        Entity enemyDisplay = CombatAnimalFactory.createWaterBossCombatEntity();
+        spawnEntityAt(enemyDisplay, new GridPoint2(800, 346), true, true);
+        this.enemyDisplay = enemyDisplay;
     }
 
     /** Spawn a combat enemy. Different to a regular enemy npc */
     private void spawnAirBoss() {
-        Entity combatEnemyNPC = BossFactory.createAirBossCombatEntity();
-        spawnEntityAt(combatEnemyNPC, new GridPoint2(800, 346), true, true);
+        Entity enemyDisplay = CombatAnimalFactory.createAirBossCombatEntity();
+        spawnEntityAt(enemyDisplay, new GridPoint2(800, 346), true, true);
+        this.enemyDisplay = enemyDisplay;
     }
 
     /** The following functions spawn chicken, monkey, and frog entities as NPC's for static combat

--- a/source/core/src/main/com/csse3200/game/entities/factories/CombatAnimalFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/CombatAnimalFactory.java
@@ -253,31 +253,93 @@ public class CombatAnimalFactory {
         BaseEnemyEntityConfig config = configs.joey;
         joeyEnemy.setEnemyType(Entity.EnemyType.JOEY);
 
+        TextureAtlas joeyAtlas = ServiceLocator.getResourceService().getAsset(config.getSpritePath(), TextureAtlas.class);
+        AnimationRenderComponent animator = new AnimationRenderComponent(joeyAtlas);
+
+        animator.addAnimation("combat_idle", 0.2f, Animation.PlayMode.LOOP);
+        animator.addAnimation("combat_move", 0.5f, Animation.PlayMode.LOOP);
+
         joeyEnemy
-                .addComponent(new TextureRenderComponent("images/joey_idle.png"));
+                .addComponent(animator)
+                .addComponent(new CombatAnimationController());
         joeyEnemy.scaleHeight(90.0f);
 
         return joeyEnemy;
     }
 
     /**
-     * Creates a Kangaroo Boss entity for combat. This functions the same as createKangaBossEntity() however
-     * there is no chase task included. This is where abilities components will be added.
-     * loaded.
+     * Creates kangaroo boss enemy as entity for combat display
      *
      * @return entity
-     */
+     * */
     public static Entity createKangaBossCombatEntity() {
         Entity kangarooBoss = createCombatBaseEnemy();
         BaseEnemyEntityConfig config = configs.kangarooBoss;
         kangarooBoss.setEnemyType(Entity.EnemyType.KANGAROO);
 
+        TextureAtlas kangarooAtlas = ServiceLocator.getResourceService().getAsset(config.getSpritePath(), TextureAtlas.class);
+        AnimationRenderComponent animator = new AnimationRenderComponent(kangarooAtlas);
+
+        animator.addAnimation("combat_idle", 1.0f, Animation.PlayMode.LOOP);
+        animator.addAnimation("combat_move", 0.1f, Animation.PlayMode.LOOP);
+
         kangarooBoss
-                .addComponent(new TextureRenderComponent("images/final_boss_kangaroo_idle.png"));
+                .addComponent(animator)
+                .addComponent(new CombatAnimationController());
 
         kangarooBoss.scaleHeight(120.0f);
 
         return kangarooBoss;
+    }
+
+    /**
+     * Creates water boss enemy as entity for combat display
+     *
+     * @return entity
+     * */
+    public static Entity createWaterBossCombatEntity() {
+        Entity waterBoss = createCombatBaseEnemy();
+        BaseEnemyEntityConfig config = configs.waterBoss;
+        waterBoss.setEnemyType(Entity.EnemyType.WATER_BOSS);
+
+        TextureAtlas waterBossAtlas = ServiceLocator.getResourceService().getAsset(config.getSpritePath(), TextureAtlas.class);
+        AnimationRenderComponent animator = new AnimationRenderComponent(waterBossAtlas);
+
+        animator.addAnimation("combat_idle", 1.0f, Animation.PlayMode.LOOP);
+        animator.addAnimation("combat_move", 0.1f, Animation.PlayMode.LOOP);
+
+        waterBoss
+                .addComponent(animator)
+                .addComponent(new CombatAnimationController());
+
+        waterBoss.scaleHeight(120.0f);
+
+        return waterBoss;
+    }
+
+    /**
+     * Creates air boss enemy as entity for combat display
+     *
+     * @return entity
+     * */
+    public static Entity createAirBossCombatEntity() {
+        Entity airBoss = createCombatBaseEnemy();
+        BaseEnemyEntityConfig config = configs.airBoss;
+        airBoss.setEnemyType(Entity.EnemyType.AIR_BOSS);
+
+        TextureAtlas airBossAtlas = ServiceLocator.getResourceService().getAsset(config.getSpritePath(), TextureAtlas.class);
+        AnimationRenderComponent animator = new AnimationRenderComponent(airBossAtlas);
+
+        animator.addAnimation("combat_idle", 1.0f, Animation.PlayMode.LOOP);
+        animator.addAnimation("combat_move", 0.1f, Animation.PlayMode.LOOP);
+
+        airBoss
+                .addComponent(animator)
+                .addComponent(new CombatAnimationController());
+
+        airBoss.scaleHeight(120.0f);
+
+        return airBoss;
     }
 
     private CombatAnimalFactory() {


### PR DESCRIPTION
# Description

This PR implements entity animations in the Combat Screen by implementing a separate CombatAnimationController and CombatAnimalFactory. Different combat animations `combat_idle` and `combat_move` can be called from the CombatButtonDisplay. The animations are implemented for all bosses, including Kanga, Leviathan, Griffin, and Joey.

Closes #342

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Majority of the testing done has been visual testing. Going into combat with an enemy listed above, check that it displays the enemy's idle animation straight away, and its move animation when a combat Move (i.e. Attack, Guard, Sleep) is triggered. Unit testing will be completed when we've figured out how to do that with UI Components.

https://github.com/user-attachments/assets/40540ba2-1756-4a13-9167-f0caace2fec9

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
