### PR TITLE
fix unlock event function

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/forest/ForestGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/forest/ForestGameArea.java
@@ -124,6 +124,7 @@ public class ForestGameArea extends GameArea {
       player.getEvents().addListener("spawnLandBoss", this::spawnKangarooBoss);
       player.getEvents().addListener("spawnWaterBoss", this::spawnWaterBoss);
       player.getEvents().addListener("spawnAirBoss", this::spawnAirBoss);
+      player.getEvents().addListener("unlockArea", this::unlockArea);
       kangarooBossSpawned = false;
       waterBossSpawned = false;
       airBossSpawned = false;
@@ -137,13 +138,13 @@ public class ForestGameArea extends GameArea {
       player.getComponent(QuestManager.class).loadQuests();
   }
 
-//  /**
-//   * Unlock an area of the map
-//   */
-//  @Override
-//  public void unlockArea(String area) {
-//    terrain.getMap().getLayers().get(area).setVisible(false);
-//  }
+  /**
+   * Unlock an area of the map
+   */
+  @Override
+  public void unlockArea(String area) {
+    terrain.getMap().getLayers().get(area).setVisible(false);
+  }
 
   /**
    * Spawn the world barrier
@@ -283,9 +284,6 @@ public class ForestGameArea extends GameArea {
     this.terrain = terrainFactory.createTerrain(TerrainType.FOREST_DEMO, PLAYER_SPAWN, MAP_SIZE, MapType.FOREST);
     Entity terrain = new Entity().addComponent(this.terrain);
 
-    terrain.getEvents().addListener(UNLOCK_AREA_EVENT, this::unlockArea);
-
-    terrain.getEvents().trigger(UNLOCK_AREA_EVENT, "water");
     spawnEntity(terrain);
   }
 


### PR DESCRIPTION
# Description

Add `unlockArea()` to unlock a area.

Fixes / Closes # (issue)
Fix the issue where the terrain was calling function that crash the game 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Successfully enter without crash the game
- [x] press `U` to check area is unlocked as expected


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
