### PR TITLE
Bug Fix to Incorrect Handling of Losing in Combat

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/combat/CombatActions.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/CombatActions.java
@@ -84,6 +84,7 @@ public class CombatActions extends Component {
     int statusRestoreMult = 2;
     // Clear the player inventory and wipe their current experience progress
     manager.getPlayerStats().setExperience(lossExp);
+    entity.getEvents().trigger("combatLossInvClear");
 
     // Reset player health and hunger back to half
     manager.getPlayerStats().setHealth(maxPlayerHealth/statusRestoreMult);

--- a/source/core/src/main/com/csse3200/game/components/combat/CombatActions.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/CombatActions.java
@@ -84,7 +84,8 @@ public class CombatActions extends Component {
     int statusRestoreMult = 2;
     // Clear the player inventory and wipe their current experience progress
     manager.getPlayerStats().setExperience(lossExp);
-    entity.getEvents().trigger("combatLossInvClear");
+    this.manager.getPlayer().getComponent(PlayerInventoryDisplay.class).clearInventory();
+    this.manager.getPlayer().getComponent(PlayerInventoryDisplay.class).regenerateDisplay();
 
     // Reset player health and hunger back to half
     manager.getPlayerStats().setHealth(maxPlayerHealth/statusRestoreMult);

--- a/source/core/src/main/com/csse3200/game/components/combat/CombatActions.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/CombatActions.java
@@ -79,9 +79,15 @@ public class CombatActions extends Component {
   private void onCombatLoss(Entity enemy) {
     logger.debug("Returning to main game screen after combat loss.");
     int lossExp = 0;
+    int maxPlayerHealth = manager.getPlayerStats().getMaxHealth();
+    int maxPlayerHunger = manager.getPlayerStats().getMaxHunger();
+    int statusRestoreMult = 2;
     // Clear the player inventory and wipe their current experience progress
     manager.getPlayerStats().setExperience(lossExp);
 
+    // Reset player health and hunger back to half
+    manager.getPlayerStats().setHealth(maxPlayerHealth/statusRestoreMult);
+    manager.getPlayerStats().setHunger(maxPlayerHunger/statusRestoreMult);
 
     // For CombatStatsDisplay to update
     entity.getEvents().trigger("onCombatLoss", manager.getPlayerStats());

--- a/source/core/src/main/com/csse3200/game/components/combat/CombatActions.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/CombatActions.java
@@ -74,9 +74,15 @@ public class CombatActions extends Component {
 
   /**
    * Swaps from combat screen to Game Over screen upon the event that the player is defeated in battle.
+   * Also handles the consequences of losing (inventory and experience loss)
    */
   private void onCombatLoss(Entity enemy) {
     logger.debug("Returning to main game screen after combat loss.");
+    int lossExp = 0;
+    // Clear the player inventory and wipe their current experience progress
+    manager.getPlayerStats().setExperience(lossExp);
+
+
     // For CombatStatsDisplay to update
     entity.getEvents().trigger("onCombatLoss", manager.getPlayerStats());
 

--- a/source/core/src/main/com/csse3200/game/components/combat/CombatButtonDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/CombatButtonDisplay.java
@@ -290,8 +290,7 @@ public class CombatButtonDisplay extends UIComponent {
         if (winStatus) {
             endText = new String[][]{{"You tamed the wild animal. Say hi to your new friend!"}};
         } else {
-            endText = new String[][]{{"You lost to the beast. Try leveling up, and powering up " +
-                    "before battling again."}};
+            endText = new String[][]{{"You lost. Try leveling up, and try again."}};
         }
         ServiceLocator.getDialogueBoxService().updateText(endText, DialogueBoxService.DialoguePriority.BATTLE);
     }

--- a/source/core/src/main/com/csse3200/game/components/combat/CombatManager.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/CombatManager.java
@@ -482,7 +482,7 @@ public class CombatManager extends Component {
                 GameState.resetState();
                 SaveHandler.delete(GameState.class, "saves", FileLoader.Location.LOCAL);
             } else {
-                this.getEntity().getEvents().trigger("combatLoss");
+                this.getEntity().getEvents().trigger("combatLoss", enemy);
                 //Clear inventory/other normal death events
             }
             // nullifyCombatDialogueListener(); // remove the listener added for animation syncing

--- a/source/core/src/main/com/csse3200/game/components/combat/CombatStatsDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/CombatStatsDisplay.java
@@ -72,6 +72,7 @@ public class CombatStatsDisplay extends UIComponent {
         entity.getEvents().addListener("onSleep", this::updateHealthUI);
         entity.getEvents().addListener("onSleep", this::updatePlayerHungerUI);
         entity.getEvents().addListener("onCombatWin", this::updatePlayerExperienceUI);
+        entity.getEvents().addListener("onCombatLoss", this::updatePlayerExperienceUI);
         entity.getEvents().addListener("useItem", this::updateHealthUI);
         entity.getEvents().addListener("useItem", this::updatePlayerHungerUI);
         entity.getEvents().addListener("statusEffectAdded", this::updateStatusEffectUI);

--- a/source/core/src/main/com/csse3200/game/components/inventory/CombatInventoryDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/inventory/CombatInventoryDisplay.java
@@ -26,7 +26,6 @@ public class CombatInventoryDisplay extends InventoryDisplay {
     public void create() {
         super.create();
         entity.getEvents().addListener("itemUsedInCombat", this::useItemInCombat);
-        entity.getEvents().addListener("combatLossInvClear", this.inventory::clearInventory);
     }
 
     @Override

--- a/source/core/src/main/com/csse3200/game/components/inventory/CombatInventoryDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/inventory/CombatInventoryDisplay.java
@@ -26,6 +26,7 @@ public class CombatInventoryDisplay extends InventoryDisplay {
     public void create() {
         super.create();
         entity.getEvents().addListener("itemUsedInCombat", this::useItemInCombat);
+        entity.getEvents().addListener("combatLossInvClear", this.inventory::clearInventory);
     }
 
     @Override

--- a/source/core/src/main/com/csse3200/game/components/inventory/PlayerInventoryDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/inventory/PlayerInventoryDisplay.java
@@ -106,4 +106,12 @@ public class PlayerInventoryDisplay extends InventoryDisplay {
         }
         super.consumeItem(item, context, index);
     }
+
+    /**
+     * Clears the inventory of the player (used to empty inventory when loss condition satisfied in combat)
+     */
+    public void clearInventory() {
+        this.inventory.clearInventory();
+        potions.clear();
+    }
 }


### PR DESCRIPTION
# Description

Previously, nothing special would happen when a combat loss with a regular enemy NPC was experienced. However now, combat loss is handled properly. When the player loses to a regular enemy NPC, upon spawning back into the main map, their whole inventory is wiped and all their current experience progress in this level (eg they're level 2 with 80 experience points on the way to level 3, but once they lose, they're still level 2 but with no experience points on the way to level 3). However, they are respawned with half of their hunger and health so that they have something to work with after dying.

Fixes / Closes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Visual Testing through play throughs has been completed to ensure this works to test this there's two ways.

Quick Way:
Walk around and pick-up some items before going into combat (don't need much, literally one or two will do). Go into combat and kill one animal (so that you gain some exp)(You can use insta-kill if you want). Then after this go into combat again and click the insta-lose button. You will see that when returning to the overworld, you lose all your progress experience, your health and hunger are now at 50%, and your inventory is gone (on the sidebar).

Long Way:
Exactly the same as the short way, except you defeat the first enemy manually using attack button. And before going into the second combat, find a monkey that can damage you enough so that when you go into combat with it, you can almost guarantee that if you keep guarding or sleeping that if it attacks, it will kill you (this way is kind of painful because it takes a minute for the monkey to throw enough bananas to damage you enough).


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
