### PR TITLE
improved roulette feature and fixed bug

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/animal/AnimalRouletteActions1.java
+++ b/source/core/src/main/com/csse3200/game/components/animal/AnimalRouletteActions1.java
@@ -6,7 +6,6 @@ import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.csse3200.game.GdxGame;
 import com.csse3200.game.gamestate.GameState;
 import com.csse3200.game.screens.StoryScreen;
-import com.csse3200.game.ui.AlertBox;
 import com.csse3200.game.ui.pop_up_dialog_box.PopUpHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,11 +14,11 @@ public class AnimalRouletteActions1 {
     private static final Logger logger = LoggerFactory.getLogger(AnimalRouletteActions1.class);
     private final AnimalRouletteDisplay1 display;
     private final PopUpHelper dialogHelper;
-    private static Image selectedAnimalImage;
     private final GdxGame game;
     private static String selectedAnimalImagePath;
     private int currentAnimalIndex = 0;
     private final String[] animalImagePaths;
+    private int lastViewedAnimalIndex = -1;
 
     public AnimalRouletteActions1(AnimalRouletteDisplay1 display, PopUpHelper dialogHelper, GdxGame game) {
         this.display = display;
@@ -34,19 +33,6 @@ public class AnimalRouletteActions1 {
     }
 
     private void addListeners() {
-        display.getSelectButton().addListener(new ClickListener() {
-            @Override
-            public void clicked(InputEvent event, float x, float y) {
-                if (selectedAnimalImage != null) {
-                    logger.debug("Select button clicked with animal selected");
-                    switchToStoryScreen();
-                } else {
-                    logger.debug("No animal selected");
-                    showSelectionAlert();
-                }
-            }
-        });
-
         display.getBackButton().addListener(new ClickListener() {
             @Override
             public void clicked(InputEvent event, float x, float y) {
@@ -75,7 +61,7 @@ public class AnimalRouletteActions1 {
             @Override
             public void clicked(InputEvent event, float x, float y) {
                 logger.debug("Animal image clicked");
-                selectCurrentAnimal();
+                viewCurrentAnimal();
                 showAnimalDialog();
             }
         });
@@ -84,81 +70,57 @@ public class AnimalRouletteActions1 {
     private void showPreviousAnimal() {
         currentAnimalIndex = (currentAnimalIndex - 1 + animalImagePaths.length) % animalImagePaths.length;
         updateDisplayedAnimal();
+        updateBackground();
     }
 
     private void showNextAnimal() {
         currentAnimalIndex = (currentAnimalIndex + 1) % animalImagePaths.length;
         updateDisplayedAnimal();
+        updateBackground();
     }
 
     private void updateDisplayedAnimal() {
         display.updateAnimalImage(animalImagePaths[currentAnimalIndex]);
     }
 
-    private void selectCurrentAnimal() {
-        // Reset appearance of previously selected animal
-        if (selectedAnimalImage != null) {
-            resetAnimalAppearance(selectedAnimalImage);
+    private void updateBackground() {
+        display.updateBackground(currentAnimalIndex);
+    }
+
+    private void viewCurrentAnimal() {
+        // Reset color of previously viewed animal if exists
+        if (lastViewedAnimalIndex != -1) {
+            display.getAnimalImage().setColor(1, 1, 1, 1);
         }
 
-        // Select the new animal
-        selectedAnimalImage = display.getAnimalImage();
+        lastViewedAnimalIndex = currentAnimalIndex;
         selectedAnimalImagePath = animalImagePaths[currentAnimalIndex];
         GameState.player.selectedAnimalPath = selectedAnimalImagePath;
-        logger.debug("Animal selected: {}", selectedAnimalImagePath);
+        logger.debug("Animal viewed: {}", selectedAnimalImagePath);
 
-        // Highlight the selected animal
-        highlightSelectedAnimal(selectedAnimalImage);
-    }
-    /**
-     * Highlights the selected animal with a red border or tint.
-     * @param animalImage The Image of the selected animal to be highlighted.
-     */
-    private void highlightSelectedAnimal(Image animalImage) {
-
-        animalImage.setColor(1, 0, 0, 1);  // Red color (R, G, B, A)
-    }
-
-    /**
-     * Resets the appearance of the previously selected animal.
-     * @param animalImage The Image of the previously selected animal to be reset.
-     */
-    private void resetAnimalAppearance(Image animalImage) {
-        animalImage.setColor(1, 1, 1, 1);  // Reset to original
-    }
-
-
-
-    private void showSelectionAlert() {
-        AlertBox alertBox = new AlertBox("Please select an animal first.", display.getSkin(), 400f, 200f);
-        alertBox.display(display.getStage());
-    }
-
-    void showAnimalDialog(int animalIndex, String animalImagePath) {
-        String title = "Animal " + (animalIndex + 1);
-        String content = display.getAnimalDescription(animalIndex);
-        dialogHelper.displayDialog(title, content, animalImagePath, 900f, 500f, animalIndex);
-    }
-
-    private void showAnimalDialog() {
-        showAnimalDialog(currentAnimalIndex, selectedAnimalImagePath);
+        // Highlight the viewed animal
+        display.getAnimalImage().setColor(1, 0, 0, 1);
     }
 
     private void switchToStoryScreen() {
         game.setScreen(new StoryScreen(game, display.getAnimalType(currentAnimalIndex)));
     }
 
-    public void resetSelection() {
-        selectedAnimalImage = null;
-        selectedAnimalImagePath = null;
-        currentAnimalIndex = 0;
-        updateDisplayedAnimal();
+    void showAnimalDialog(int animalIndex, String animalImagePath) {
+        String title = "Animal " + (animalIndex + 1);
+        String content = display.getAnimalDescription(animalIndex);
+        dialogHelper.displayDialog(title, content, animalImagePath, 900f, 500f, animalIndex, () -> switchToStoryScreen());
     }
 
-    void selectAnimal(Image animalImage, String animalImagePath) {
-        selectedAnimalImage = animalImage;
-        selectedAnimalImagePath = animalImagePath;
-        GameState.player.selectedAnimalPath = animalImagePath;
-        logger.debug("Animal selected: {}", animalImage.getName());
+    private void showAnimalDialog() {
+        showAnimalDialog(currentAnimalIndex, selectedAnimalImagePath);
+    }
+
+    public void resetSelection() {
+        selectedAnimalImagePath = null;
+        currentAnimalIndex = 0;
+        lastViewedAnimalIndex = -1;
+        updateDisplayedAnimal();
+        updateBackground();
     }
 }

--- a/source/core/src/main/com/csse3200/game/components/animal/AnimalRouletteDisplay1.java
+++ b/source/core/src/main/com/csse3200/game/components/animal/AnimalRouletteDisplay1.java
@@ -15,16 +15,15 @@ public abstract class AnimalRouletteDisplay1 {
     private final Stage stage;
     private final Skin skin;
     private Image animalImage;
-    private final CustomButton selectButton;
     private final CustomButton backButton;
     private final CustomButton leftButton;
     private final CustomButton rightButton;
+    private Image backgroundImage;
 
     public AnimalRouletteDisplay1(Stage stage, Skin skin) {
         this.stage = stage;
         this.skin = skin;
 
-        this.selectButton = new CustomButton("Ready?", skin);
         this.backButton = new CustomButton("Go Back", skin);
         this.leftButton = new CustomButton("<", skin);
         this.rightButton = new CustomButton(">", skin);
@@ -35,7 +34,9 @@ public abstract class AnimalRouletteDisplay1 {
     protected abstract String getBackgroundImagePath();
 
     private void initializeDisplay() {
-        BackgroundImage backgroundImage = new BackgroundImage(getBackgroundImagePath());
+        // Initialize background with default (first animal)
+        backgroundImage = new Image(new Texture(getBackgroundPath(0)));
+        backgroundImage.setFillParent(true);
         stage.addActor(backgroundImage);
 
         Table mainTable = new Table();
@@ -52,14 +53,20 @@ public abstract class AnimalRouletteDisplay1 {
 
         mainTable.add(animalTable).expand().center();
         mainTable.row();
+        mainTable.add(backButton).width(200).height(50).padBottom(50);
+    }
 
-        Table buttonTable = new Table();
+    private String getBackgroundPath(int animalIndex) {
+        String[] backgrounds = {
+                "images/animal/JungleAnimalSelectionBG.jpeg",  // Dog background
+                "images/animal/WaterAnimalSelectionBG.jpeg",   // Croc background
+                "images/animal/SkyAnimalSelectionBG.jpeg"      // Bird background
+        };
+        return backgrounds[animalIndex];
+    }
 
-
-        buttonTable.add(backButton).width(200).height(50).padRight(20);
-        buttonTable.add(selectButton).width(200).height(50);
-
-        mainTable.add(buttonTable).padBottom(50);
+    public void updateBackground(int animalIndex) {
+        backgroundImage.setDrawable(new Image(new Texture(getBackgroundPath(animalIndex))).getDrawable());
     }
 
 
@@ -102,10 +109,6 @@ public abstract class AnimalRouletteDisplay1 {
 
     public Image getAnimalImage() {
         return animalImage;
-    }
-
-    public CustomButton getSelectButton() {
-        return selectButton;
     }
 
     public CustomButton getBackButton() {

--- a/source/core/src/main/com/csse3200/game/ui/pop_up_dialog_box/PopUpHelper.java
+++ b/source/core/src/main/com/csse3200/game/ui/pop_up_dialog_box/PopUpHelper.java
@@ -39,8 +39,8 @@ public class PopUpHelper {
      */
     public void displayDialog(String title, String content, String animalImagePath, float width, float height, int animalIndex, Runnable callback) {
         PopupDialogBox dialogBox = new PopupDialogBox(
-                new String[]{title},
-                new String[]{content},
+                title,
+                content,
                 animalImagePath,
                 skin,
                 width,

--- a/source/core/src/main/com/csse3200/game/ui/pop_up_dialog_box/PopupDialogBox.java
+++ b/source/core/src/main/com/csse3200/game/ui/pop_up_dialog_box/PopupDialogBox.java
@@ -9,160 +9,107 @@ import com.badlogic.gdx.scenes.scene2d.ui.*;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.csse3200.game.ui.CustomButton;
 
-/**
- * A customizable popup dialog box that displays animal information and health bars.
- * This dialog box allows navigation through multiple pages of content using a confirm button.
- */
 public class PopupDialogBox extends Dialog {
     private final Label titleLabel;
     private final Label contentLabel;
-
     private final Image animalImage;
     private Table statsTable;
     private Runnable callback;
-
     private final float dialogWidth;
     private final float dialogHeight;
+    private final CustomButton enterKingdomButton;
+    private final CustomButton backButton;
+    private int animalIndex = 0;
 
-    private String[] titles;
-    private String[] content;
-    private int currentIndex = 0;
+    private final String[] kingdomButtonTexts = {
+            "Enter Land Kingdom",    // Dog
+            "Enter Water Kingdom",   // Croc
+            "Enter Air Kingdom"      // Bird
+    };
 
-    private int[] speedStats;
-    private int[] defenseStats;
-    private int[] strengthStats;
-    private final CustomButton nextButton;  // Changed to CustomButton
-    private final CustomButton backButton;  // Changed to CustomButton
-
-    private int animalIndex = 0; // Default to bird stats, should be updated based on selection
-
-    /**
-     * Constructs a new PopupDialogBox.
-     *
-     * @param titles         Array of titles for each page of content.
-     * @param content        Array of content for each page.
-     * @param animalImagePath Path to the image of the animal to be displayed.
-     * @param skin           Skin to be used for the UI elements.
-     * @param dialogWidth    Width of the dialog box.
-     * @param dialogHeight   Height of the dialog box.
-     * @param speedStats     Array of speed stats for different animals.
-     * @param defenseStats   Array of defense stats for different animals.
-     * @param strengthStats  Array of strength stats for different animals.
-     */
-    public PopupDialogBox(String[] titles, String[] content, String animalImagePath, Skin skin, float dialogWidth, float dialogHeight,
+    public PopupDialogBox(String title, String content, String animalImagePath, Skin skin,
+                          float dialogWidth, float dialogHeight,
                           int[] speedStats, int[] defenseStats, int[] strengthStats) {
         super("", skin);
-        Texture bgTexture = new Texture(Gdx.files.internal("images/animal/lightblue.png")); // Load the background image
-        Image backgroundImage = new Image(bgTexture); // Create an Image from the texture
+
+        Texture bgTexture = new Texture(Gdx.files.internal("images/animal/lightblue.png"));
+        Image backgroundImage = new Image(bgTexture);
         this.getContentTable().setBackground(backgroundImage.getDrawable());
-        this.titles = titles;
-        this.content = content;
+
         this.dialogWidth = dialogWidth + 200;
         this.dialogHeight = dialogHeight + 150;
 
-        // Load the animal image
         Texture animalTexture = new Texture(Gdx.files.internal(animalImagePath));
         animalImage = new Image(animalTexture);
 
-        // Initialize stats arrays
-        this.speedStats = speedStats;
-        this.defenseStats = defenseStats;
-        this.strengthStats = strengthStats;
-
-        // Initialize labels and buttons
-        titleLabel = new Label(titles[currentIndex], skin);
+        titleLabel = new Label(title, skin);
         titleLabel.setFontScale(0.4f);
         titleLabel.setColor(Color.CYAN);
 
-        contentLabel = new Label(content[currentIndex], skin);
+        contentLabel = new Label(content, skin);
         contentLabel.setWrap(true);
 
-        nextButton = new CustomButton("Confirm choice", skin);
+        enterKingdomButton = new CustomButton(kingdomButtonTexts[0], skin);
         backButton = new CustomButton("Back", skin);
-        nextButton.setSize(200, 50);
-        backButton.setSize(200, 50);
 
         addActionListeners();
-        createDialogLayout();
+        createDialogLayout(speedStats, defenseStats, strengthStats);
     }
 
-    public void setCallback(Runnable callback) {
-        this.callback = callback;
-    }
-
-    /**
-     * Adds action listeners to the buttons in the dialog.
-     */
     private void addActionListeners() {
-        nextButton.addListener(new ChangeListener() {
+        enterKingdomButton.addListener(new ChangeListener() {
             @Override
             public void changed(ChangeEvent event, Actor actor) {
-                proceedToNext();
+                if (callback != null) {
+                    callback.run();
+                }
+                hide();
             }
         });
 
         backButton.addListener(new ChangeListener() {
             @Override
             public void changed(ChangeEvent event, Actor actor) {
-                hide(); // Simple back action for now
+                hide();
             }
         });
     }
 
-    /**
-     * Creates and configures the layout of the dialog box.
-     */
-    private void createDialogLayout() {
+    private void createDialogLayout(int[] speedStats, int[] defenseStats, int[] strengthStats) {
         Table contentTable = new Table();
         contentTable.pad(20);
 
-        // Image on the left, text and stats table on the right
         Table rightTable = new Table();
-
-        // Text on top 1/3 of the right side
         Table textTable = new Table();
         textTable.add(contentLabel).width(dialogWidth * 0.5f).padTop(30).top().expandY();
         rightTable.add(textTable).width(dialogWidth * 0.5f).expandX().row();
 
-        // Stats table under text
         Table statsContainer = new Table();
         statsTable = new Table();
-        statsTable.add(new Label("STATS", getSkin())).colspan(2).padBottom(10).row();
+        updateStatsTable(speedStats, defenseStats, strengthStats);
         statsContainer.add(statsTable).expand().top().row();
         rightTable.add(statsContainer).width(dialogWidth * 0.5f).expandX().fillY().top();
 
-        // Add image and right table to the content layout
         Table innerTable = new Table();
         innerTable.add(animalImage).width(dialogWidth * 0.4f).height(dialogHeight * 0.8f).padRight(20);
         innerTable.add(rightTable).width(dialogWidth * 0.6f).expandY().top();
 
-        // Add innerTable to contentTable
         contentTable.add(innerTable).expandX().center().row();
 
-        // Create a new table for buttons and align them horizontally
         Table buttonTable = new Table();
-        buttonTable.add(backButton).width(200).height(50).padRight(10); // Add back button first
-        buttonTable.add(nextButton).width(200).height(50); // Add next button
+        buttonTable.add(backButton).width(200).height(50).padRight(10);
+        buttonTable.add(enterKingdomButton).width(200).height(50);
 
-        // Add buttonTable to contentTable at the bottom
         contentTable.add(buttonTable).padTop(20).colspan(2).center().expandX();
 
-        // Set content table to the dialog box
         getContentTable().add(contentTable).expand().center();
 
-        // Set the size and position of the dialog box
         setSize(dialogWidth, dialogHeight);
-        setPosition((Gdx.graphics.getWidth() - getWidth()) / 2f, (Gdx.graphics.getHeight() - getHeight()) / 2f);
-
-        updateStatsTable(); // Update stats table with the current animal's stats
+        setPosition((Gdx.graphics.getWidth() - getWidth()) / 2f,
+                (Gdx.graphics.getHeight() - getHeight()) / 2f);
     }
 
-
-    /**
-     * Updates the stats table with the current animal's stats.
-     */
-    private void updateStatsTable() {
-        // Clear previous stats
+    private void updateStatsTable(int[] speedStats, int[] defenseStats, int[] strengthStats) {
         statsTable.clear();
         statsTable.add(new Label("STATS", getSkin())).colspan(2).padBottom(10).row();
         statsTable.add(new Label("SPEED:", getSkin())).left();
@@ -173,39 +120,16 @@ public class PopupDialogBox extends Dialog {
         statsTable.add(new Label(String.valueOf(strengthStats[animalIndex]), getSkin())).right().row();
     }
 
-    /**
-     * Moves to the next page of content in the dialog box. If all pages are shown, hides the dialog.
-     */
-    private void proceedToNext() {
-        currentIndex++;
-        if (currentIndex < titles.length) {
-            titleLabel.setText(titles[currentIndex]);
-            contentLabel.setText(content[currentIndex]);
-            updateStatsTable(); // Update stats table when changing pages
-        } else {
-            hide();  // Hide dialog when content is done
-            if (callback != null) {
-                callback.run();  // Execute the callback when dialog is closed
-            }
-        }
-    }
-
-    /**
-     * Displays the dialog box on the specified stage.
-     *
-     * @param stage The stage on which to display the dialog box.
-     */
-    public void display(Stage stage) {
-        stage.addActor(this);
-    }
-
-    /**
-     * Sets the index of the animal for which stats should be displayed.
-     *
-     * @param animalIndex Index of the selected animal (0 for bird, 1 for croc, 2 for dog).
-     */
     public void setAnimalIndex(int animalIndex) {
         this.animalIndex = animalIndex;
-        updateStatsTable();  // Update stats when the selected animal changes
+        enterKingdomButton.setLabelText(kingdomButtonTexts[animalIndex]);
+    }
+
+    public void setCallback(Runnable callback) {
+        this.callback = callback;
+    }
+
+    public void display(Stage stage) {
+        stage.addActor(this);
     }
 }


### PR DESCRIPTION
# Description

modified roulette screen.
game now takes user to roulette screen where user can view animals belonging to each kingdom. 
matched background of animal in view to kingdom (ie. dog has jungle background, crocodile has water background and bird has sky background)
user is taken to story screen/main game screen from pop up dialog box directly instead of multiple steps involving returning to roulette and clicking start
fixed bug where end of any combat ended game entirely

Fixes / Closes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] AnimalRouletteDisplayTest

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
