### PR TITLE
[Team 2] fixing the hive disposing of bees multiple times

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/forest/ForestGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/forest/ForestGameArea.java
@@ -684,7 +684,7 @@ public class ForestGameArea extends GameArea {
         spawnShooterEnemy(generator, ForestSpawnConfig.NUM_MACAW, 0.1, 3);
 
         //Hive
-        generator = () -> ProjectileFactory.createHive(player);
+        generator = () -> ProjectileFactory.createHive(player, enemies);
         spawnHive(generator, 5, 0.1, 1);
     }
 

--- a/source/core/src/main/com/csse3200/game/components/tasks/HiveTask.java
+++ b/source/core/src/main/com/csse3200/game/components/tasks/HiveTask.java
@@ -20,8 +20,6 @@ import java.util.ArrayList;
  * Requires an entity with a PhysicsMovementComponent.
  */
 public class HiveTask extends DefaultTask implements PriorityTask {
-    private static final Logger logger = LoggerFactory.getLogger(HiveTask.class);
-
     private final float waitTime; // Time to wait between bee spawns
     private final Entity target;  // The target that bees will chase
     private float elapsedTime = 0; // Tracks elapsed time for spawning
@@ -71,6 +69,14 @@ public class HiveTask extends DefaultTask implements PriorityTask {
         // If the player is close enough to the hive, dispose of the hive and all bees
         if (Vector2.dst2(ownerX, ownerY, playerX, playerY) < 10f) {
             for (Entity e : entities) {
+                boolean skip = true;
+                for (Entity entity : owner.getEntity().getEnemies()) {
+                    if (e.equals(entity)) {
+                        skip = false;
+                        break;
+                    }
+                }
+                if (skip) continue;
                 e.setEnabled(false);
                 AnimationRenderComponent animationRenderComponent = e.getComponent(AnimationRenderComponent.class);
                 animationRenderComponent.stopAnimation();

--- a/source/core/src/main/com/csse3200/game/entities/Entity.java
+++ b/source/core/src/main/com/csse3200/game/entities/Entity.java
@@ -6,10 +6,13 @@ import com.badlogic.gdx.utils.IntMap;
 import com.csse3200.game.components.Component;
 import com.csse3200.game.components.ComponentType;
 import com.csse3200.game.events.EventHandler;
+import com.csse3200.game.lighting.components.LightingComponent;
 import com.csse3200.game.rendering.AnimationRenderComponent;
 import com.csse3200.game.services.ServiceLocator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /**
  * Core entity class. Entities exist in the game and are updated each frame. All entities have a
@@ -40,6 +43,7 @@ public class Entity {
   private boolean isPlayer = false;
   private boolean isNormalEnemy = false;
   private EnemyType enemyType;
+  private List<Entity> enemies; //used for the hive
   public enum EnemyType {
     KANGAROO,
     WATER_BOSS,
@@ -357,4 +361,9 @@ public class Entity {
   public boolean isNormalEnemy() {return isNormalEnemy;}
   
   public void setIsNormalEnemy(boolean isNormalEnemy) {this.isNormalEnemy = isNormalEnemy;}
+  
+  public List<Entity> getEnemies() {
+    return enemies;
+  }
+  public void setEnemies(List<Entity> enemies) {this.enemies = enemies;}
 }

--- a/source/core/src/main/com/csse3200/game/entities/factories/ProjectileFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/ProjectileFactory.java
@@ -22,6 +22,8 @@ import com.csse3200.game.physics.components.PhysicsMovementComponent;
 import com.csse3200.game.rendering.AnimationRenderComponent;
 import com.csse3200.game.services.ServiceLocator;
 
+import java.util.List;
+
 /**
  * Factory to create non-playable projectile entities with predefined components.
  *
@@ -144,7 +146,7 @@ public class ProjectileFactory {
    * @param target entity which the spawned bees will chase
    * @return enemy hive entity
    */
-  public static Entity createHive(Entity target) {
+  public static Entity createHive(Entity target, List<Entity> enemies) {
     BaseEnemyEntityConfig config = configs.hive;
 
     AnimationRenderComponent animator =
@@ -157,6 +159,8 @@ public class ProjectileFactory {
     hive.getComponent(AITaskComponent.class).addTask(new HiveTask(target));
     hive.setEnemyType(Entity.EnemyType.HIVE);
 
+    hive.setEnemies(enemies);
+    
     return hive;
   }
   

--- a/source/core/src/test/com/csse3200/game/entities/factories/ProjectileFactoryTest.java
+++ b/source/core/src/test/com/csse3200/game/entities/factories/ProjectileFactoryTest.java
@@ -26,6 +26,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -54,10 +57,14 @@ class ProjectileFactoryTest {
             "images/griffinEffects.atlas",
             "images/hive.atlas"
     };
+    
+    private Entity Bee = new Entity();
+    private List<Entity> enemies = new ArrayList<>();
 
 
     @BeforeEach
     void setup() {
+        enemies.add(Bee);
         GameTime gameTime = mock(GameTime.class);
         when(gameTime.getDeltaTime()).thenReturn(0.02f);
         ServiceLocator.registerTimeSource(gameTime);
@@ -269,7 +276,7 @@ class ProjectileFactoryTest {
     @Test
     void TestHiveHasComponents() {
         // Create the Hive entity
-        Entity hive = ProjectileFactory.createHive(new Entity());
+        Entity hive = ProjectileFactory.createHive(new Entity(), enemies);
 
         // Verify that all required components are present
         assertNotNull(hive.getComponent(PhysicsComponent.class));
@@ -284,7 +291,7 @@ class ProjectileFactoryTest {
     @Test
     void TestHiveAnimationLoaded() {
         // Create the Hive entity
-        Entity hive = ProjectileFactory.createHive(new Entity());
+        Entity hive = ProjectileFactory.createHive(new Entity(), enemies);
 
         // Get the AnimationRenderComponent
         AnimationRenderComponent animationComponent = hive.getComponent(AnimationRenderComponent.class);
@@ -296,7 +303,7 @@ class ProjectileFactoryTest {
 
     @Test
     void TestHiveAITask() {
-        Entity hive = ProjectileFactory.createHive(new Entity());
+        Entity hive = ProjectileFactory.createHive(new Entity(), enemies);
 
         AITaskComponent aiTaskComponent = hive.getComponent(AITaskComponent.class);
 


### PR DESCRIPTION
# Description

Fixes the issue where the hive was attempting to dispose of defeated bees by calling dispose on null components. This occurred because the bees' components were already removed or uninitialized before the hive tried to dispose of them. The fix ensures that the hive only disposes of valid components, preventing errors caused by attempting to interact with null objects.

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Documents
- [Bee Hive](https://github.com/UQcsse3200/2024-studio-2/wiki/Hive-NPC)

