### PR TITLE
[Team 9] Add lines to unlock the next area after defeat boss.

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/combat/CombatActions.java
+++ b/source/core/src/main/com/csse3200/game/components/combat/CombatActions.java
@@ -2,6 +2,7 @@ package com.csse3200.game.components.combat;
 
 import com.badlogic.gdx.Screen;
 import com.csse3200.game.GdxGame;
+import com.csse3200.game.areas.MapHandler;
 import com.csse3200.game.components.CombatStatsComponent;
 import com.csse3200.game.components.Component;
 import com.csse3200.game.components.inventory.CombatInventoryDisplay;
@@ -103,16 +104,16 @@ public class CombatActions extends Component {
    * Disposes of Boss entity after post combat dialogue.
    *
    * @param bossEnemy The boss entity defeated by the player
-   * TODO: open up new area depending on bossEnemy type. Unable to do at
-   *                 this stage, map team has not completed functionality
    */
   private void onBossCombatWin(Entity bossEnemy) {
     logger.info("Boss combat complete.");
 
     if (bossEnemy.getEnemyType() == Entity.EnemyType.KANGAROO) {
       entity.getEvents().trigger("landBossDefeated");
+      MapHandler.unlockNextArea();
     } else if (bossEnemy.getEnemyType() == Entity.EnemyType.WATER_BOSS) {
       entity.getEvents().trigger("waterBossDefeated");
+      MapHandler.unlockNextArea();
     } else if (bossEnemy.getEnemyType() == Entity.EnemyType.AIR_BOSS) {
       entity.getEvents().trigger("airBossDefeated");
     }


### PR DESCRIPTION
# Description

Add two lines to unlock the next area after defeating the boss.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Add new unit tests. Pass existing tests.

New area unlock after defeating the boss.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
